### PR TITLE
Allow full URL to be used for cover

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -23,7 +23,12 @@
       {{ end }}
 
       {{ with .Params.Cover }}
-        <img src="{{ printf "img/%s" . | absURL }}" class="post-cover" />
+        {{ $imgurl := urls.Parse . }}
+        {{ if $imgurl.Scheme }}
+          <img src="{{ printf "%s" . | safeURL }}" class="post-cover" />
+        {{ else }}
+          <img src="{{ printf "img/%s" . | absURL }}" class="post-cover" />
+        {{ end }}
       {{ end }}
 
       <div class="post-content">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -17,7 +17,12 @@
     {{ end }}
 
     {{ with .Params.Cover }}
-      <img src="{{ printf "img/%s" . | absURL }}" class="post-cover" />
+      {{ $imgurl := urls.Parse . }}
+      {{ if $imgurl.Scheme }}
+        <img src="{{ printf "%s" . | safeURL }}" class="post-cover" />
+      {{ else }}
+        <img src="{{ printf "img/%s" . | absURL }}" class="post-cover" />
+      {{ end }}
     {{ end }}
 
     <div class="post-content">


### PR DESCRIPTION
I'm a recent Hugo convert. In my previous setup, I made use of Unsplash cover images, with full URLs.
This PR allows for a similar usage.

I am not fully versed yet in Hugo's templating language, so this might not be the correct way to achieve this, but it appears to work.