### PR TITLE
Add a trailing slash to URLs generated for tags

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -17,7 +17,7 @@
       {{ if .Params.tags }}
         <span class="post-tags">
           {{ range .Params.tags }}
-            #<a href="{{ (urlize (printf "tags/%s" . )) | absURL }}">{{ . }}</a>&nbsp;
+            #<a href="{{ (urlize (printf "tags/%s/" . )) | absURL }}">{{ . }}</a>&nbsp;
           {{ end }}
         </span>
       {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -11,7 +11,7 @@
     {{ if .Params.tags }}
       <span class="post-tags">
         {{ range .Params.tags }}
-          #<a href="{{ (urlize (printf "tags/%s" .)) | absURL }}">{{ . }}</a>&nbsp;
+          #<a href="{{ (urlize (printf "tags/%s/" .)) | absURL }}">{{ . }}</a>&nbsp;
         {{ end }}
       </span>
     {{ end }}


### PR DESCRIPTION
Hi @panr 

Please consider pulling in this minor change. It adds a trailing slash to the URLs generated for tags links in single.html and list.html. The trailing slash makes sure webservers don't need to do an automatic redirect to the URL with a slash, which should slightly improve performance.