### PR TITLE
Fix typo in comment

### DIFF
--- a/layouts/partials/comments.html
+++ b/layouts/partials/comments.html
@@ -1,5 +1,5 @@
 <!--
-To add comments section, please create `layouts/partial/comments.html` in your
+To add comments section, please create `layouts/partials/comments.html` in your
 Hugo directory and insert:
 
 {{ template "_internal/disqus.html" . }}


### PR DESCRIPTION
I'm rather new to Hugo, and this lead to me wondering why Hugo doesn't pick up the template I put at `layouts/partial/comments.html`.  I believe this code comment should be changed, as when I put the file at `layouts/partials/comments.html` everything works.