### PR TITLE
Make favicon configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,8 @@ paginate = 5
   fullWidthTheme = false
   # center theme with default width
   centerTheme = false
+  # set a custom favicon (default is a `themeColor` square)
+  # favicon = "favicon.ico"
 
 [languages]
   [languages.en]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -16,8 +16,10 @@
 
 <!-- Icons -->
 <link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ "img/apple-touch-icon-144-precomposed.png" | absURL }}">
-{{ with $.Site.Params.ThemeColor }}
-  <link rel="shortcut icon" href="{{ printf "img/favicon/%s.png" . | absURL }}">
+{{ if isset $.Site.Params "favicon" }}
+<link rel="shortcut icon" href="{{ $.Site.Params.favicon | absURL }}">
+{{ else }}
+<link rel="shortcut icon" href="{{ printf "img/favicon/%s.png" $.Site.Params.ThemeColor | absURL }}">
 {{ end }}
 
 <!-- Twitter Card -->


### PR DESCRIPTION
Fix #18 

Favicon can now be configured with, e.g.:

```
[params]
favicon = "favicon.ico"
```