### PR TITLE
made tag link language-sensitiv

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -19,7 +19,7 @@
     {{ if .Params.tags }}
     <span class="post-tags">
       {{ range .Params.tags }}
-      #<a href="{{ (urlize (printf "tags/%s/" . )) | absURL }}">
+      #<a href="{{ (urlize (printf "tags/%s/" . )) | absLangURL }}">
         {{- . -}}
       </a>&nbsp;
       {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,7 @@
   {{ if .Params.tags }}
   <span class="post-tags">
     {{ range .Params.tags }}
-    #<a href="{{ (urlize (printf "tags/%s/" .)) | absURL }}">{{ . }}</a>&nbsp;
+    #<a href="{{ (urlize (printf "tags/%s/" .)) | absLangURL }}">{{ . }}</a>&nbsp;
     {{ end }}
   </span>
   {{ end }}


### PR DESCRIPTION
Actual Tags link only to the base URL / default language.
With this, the Tag link will be aware of the actual language.