### PR TITLE
fixes broken page list

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -2,7 +2,7 @@
 <div class="posts">
   {{ $isntDefault := not (or (eq (trim $.Site.Params.contentTypeName " ") "posts") (eq (trim $.Site.Params.contentTypeName " ") "")) }}
   {{ $contentTypeName := cond $isntDefault (string $.Site.Params.contentTypeName) "posts" }}
-  {{ $paginator := .Paginate (where .Data.Pages "Type" $contentTypeName) }}
+  {{ $paginator := .Paginate (where .Site.RegularPages "Type" $contentTypeName) }}
 
   {{ range $paginator.Pages }}
   <div class="post on-list">


### PR DESCRIPTION
Fixes this [issue](https://github.com/gohugoio/hugoThemes/issues/678) I was having with this theme that was similar to [this](https://discourse.gohugo.io/t/hugo-not-showing-posts-but-showing-link-to-posts-index-instead/20212)