### PR TITLE
[WIP] Feature request: display index page content

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,4 +1,9 @@
 {{ define "main" }}
+{{ with .Content }}
+  <div class="index-content">
+    {{ . | markdownify }}
+  </div>
+{{ end }}
 <div class="posts">
   {{ $isntDefault := not (or (eq (trim $.Site.Params.contentTypeName " ") "posts") (eq (trim $.Site.Params.contentTypeName " ") "")) }}
   {{ $contentTypeName := cond $isntDefault (string $.Site.Params.contentTypeName) "posts" }}


### PR DESCRIPTION
It would be nice to allow content from `content/_index.md` (if any) to be displayed on the homepage, as per https://gohugo.io/templates/homepage/ and https://gohugo.io/templates/lists/#add-content-and-front-matter-to-list-pages.

This was easy to add to `layouts/_default/list.html`. The only thing left to do is to make the `posts` div appear below the `index-content` div (they're currently side-by-side due to `content`'s `display: flex`, which I'm not very familiar with). Any clue on how to fix this without breaking anything?