### PR TITLE
Import shortcode to activate PrismJS plugins

### DIFF
--- a/layouts/shortcodes/prismjs.html
+++ b/layouts/shortcodes/prismjs.html
@@ -6,8 +6,8 @@
     <pre
       class="
       {{ if .Get "lang" }}language-{{ .Get "lang" }} {{ end }}
-      {{ if .Get "line-numbers" }}line-numbers {{ end }}
-      {{ if .Get "command-line" }}command-line {{ end }}
+      {{ if .Get "line-numbers" }} line-numbers{{ end }}
+      {{ if .Get "command-line" }} command-line{{ end }}
       "
       {{/* line highlight plugin */}}
       {{ if .Get "line" }} data-line={{ .Get "line" }} {{ end }}

--- a/layouts/shortcodes/prismjs.html
+++ b/layouts/shortcodes/prismjs.html
@@ -1,0 +1,27 @@
+{{ $inner := replaceRE "^\n" "" .Inner }}
+{{ if len .Params | eq 0 }}
+  <pre><code>{{ $inner }}</code></pre>
+{{ else }}
+  {{ if .IsNamedParams }}
+    <pre
+      class="
+      {{ if .Get "lang" }}language-{{ .Get "lang" }} {{ end }}
+      {{ if .Get "line-numbers" }}line-numbers {{ end }}
+      {{ if .Get "command-line" }}command-line {{ end }}
+      "
+      {{/* line highlight plugin */}}
+      {{ if .Get "line" }} data-line={{ .Get "line" }} {{ end }}
+      {{/* line number plugin */}}
+      {{ if .Get "start" }} data-start={{ .Get "start" }} {{ end }}
+      {{/* command-line plugin */}}
+      {{ if .Get "user" }} data-user={{ .Get "user" }} {{ end }}
+      {{ if .Get "host" }} data-host={{ .Get "host" }} {{ end }}
+      {{ if .Get "prompt" }} data-prompt={{ .Get "prompt" }} {{ end }}
+      {{ if .Get "output" }} data-output={{ .Get "output" }} {{ end }}
+      ><code {{ if .Get "lang" }}class="language-{{ .Get "lang" }}"{{ end }}
+      >{{ $inner }}</code></pre>
+  {{ else }}
+    <pre class="language-{{ .Get 0 }}">
+      <code class="language-{{ .Get 0 }}">{{ $inner }}</code></pre>
+  {{ end }}
+{{ end }}

--- a/layouts/shortcodes/prismjs.html
+++ b/layouts/shortcodes/prismjs.html
@@ -3,21 +3,19 @@
   <pre><code>{{ $inner }}</code></pre>
 {{ else }}
   {{ if .IsNamedParams }}
-    <pre
-      class="
-      {{ if .Get "lang" }}language-{{ .Get "lang" }} {{ end }}
-      {{ if .Get "line-numbers" }} line-numbers{{ end }}
-      {{ if .Get "command-line" }} command-line{{ end }}
-      "
-      {{/* line highlight plugin */}}
-      {{ if .Get "line" }} data-line={{ .Get "line" }} {{ end }}
-      {{/* line number plugin */}}
-      {{ if .Get "start" }} data-start={{ .Get "start" }} {{ end }}
-      {{/* command-line plugin */}}
-      {{ if .Get "user" }} data-user={{ .Get "user" }} {{ end }}
-      {{ if .Get "host" }} data-host={{ .Get "host" }} {{ end }}
-      {{ if .Get "prompt" }} data-prompt={{ .Get "prompt" }} {{ end }}
-      {{ if .Get "output" }} data-output={{ .Get "output" }} {{ end }}
+    <pre class="
+      {{- if .Get "lang" }}language-{{ .Get "lang" }}{{ end }}
+      {{- if .Get "line-numbers" }} line-numbers{{ end }}
+      {{- if .Get "command-line" }} command-line{{ end }}"
+      {{- /* line highlight plugin */ -}}
+      {{- if .Get "line" }} data-line="{{ .Get "line" }}"{{ end }}
+      {{- /* line number plugin */ -}}
+      {{- if .Get "start" }} data-start="{{ .Get "start" }}"{{ end }}
+      {{- /* command-line plugin */ -}}
+      {{- if .Get "user" }} data-user="{{ .Get "user" }}"{{ end }}
+      {{- if .Get "host" }} data-host="{{ .Get "host" }}"{{ end }}
+      {{- if .Get "prompt" }} data-prompt="{{ .Get "prompt" }}"{{ end }}
+      {{- if .Get "output" }} data-output="{{ .Get "output" }}"{{ end }}
       ><code {{ if .Get "lang" }}class="language-{{ .Get "lang" }}"{{ end }}
       >{{ $inner }}</code></pre>
   {{ else }}


### PR DESCRIPTION
The shortcode takes named parameters that are relevant to the PrismJS
plugins that Terminal bundles.

- lang: the language contained in the code block
- line: the line number(s) to highlight
- line-numbers: displays line numbers in the margin
- command-line: activates the command-line plugin which modifies the
output to show a command line
- user: the username to display in the prompt (used with the command-line
parameter)
- host: the hostname to display in the prompt (used with the
command-line parameter)
- prompt: override the default prompt (used with the command-line
parameter)
- output: specifies which line(s) contain CLI output (used with the
command-line parameter)

Example:

```
{{< prismjs lang="bash" line="1,10-13" line-numbers="true"
command-line="true" host="jump1" user="joel" output="2-9" >}}
```

This would fix #26 