### PR TITLE
Add MathJax support on page level configuration

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -59,3 +59,11 @@
 
 <!-- Extended head section-->
 {{ partial "extended_head.html" . }}
+
+<!-- MathJax support -->
+{{ if .Params.mathJaxSupport }}
+<script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
+<script type="text/javascript" id="MathJax-script" async
+  src="https://cdn.jsdelivr.net/npm/mathjax@3/es5/tex-chtml.js">
+</script>
+{{ end }}


### PR DESCRIPTION
I needed to use LaTeX equations which is a relatively rare feature to even use. So I added the MathJax library and made it opt in on a per-page configuration using the `mathJaxSupport` variable