### PR TITLE
Tweak default front-matter.

### DIFF
--- a/archetypes/posts.md
+++ b/archetypes/posts.md
@@ -1,11 +1,11 @@
 +++
-title = "{{ replace .Name "-" " " | title }}"
-date = "{{ .Date }}"
+title = '{{ replace .Name "-" " " | title }}'
+date = '{{ .Date }}'
 draft = true
 author = '{{ index .Site.Author "name" }}'
-cover = ""
-tags = ["", ""]
-keywords = ["", ""]
-description = ""
+cover = ''
+tags = ['', '']
+keywords = ['', '']
+description = ''
 showFullContent = false
 +++

--- a/archetypes/posts.md
+++ b/archetypes/posts.md
@@ -1,11 +1,11 @@
----
-title: "{{ replace .Name "-" " " | title }}"
-date: "{{ .Date }}"
-draft: true
-author: '{{ index .Site.Author "name" }}'
-cover: ""
-tags: ["", ""]
-keywords: ["", ""]
-description: ""
-showFullContent : false
----
++++
+title = "{{ replace .Name "-" " " | title }}"
+date = "{{ .Date }}"
+draft = true
+author = '{{ index .Site.Author "name" }}'
+cover = ""
+tags = ["", ""]
+keywords = ["", ""]
+description = ""
+showFullContent = false
++++

--- a/archetypes/posts.md
+++ b/archetypes/posts.md
@@ -1,10 +1,11 @@
-+++
-title = ""
-date = ""
-author = ""
-cover = ""
-tags = ["", ""]
-keywords = ["", ""]
-description = ""
-showFullContent = false
-+++
+---
+title: "{{ replace .Name "-" " " | title }}"
+date: "{{ .Date }}"
+draft: true
+author: '{{ index .Site.Author "name" }}'
+cover: ""
+tags: ["", ""]
+keywords: ["", ""]
+description: ""
+showFullContent : false
+---


### PR DESCRIPTION
I noticed new posts weren't having their date/author being populated, so I just threw in a few variables into the archetype.

Regarding `+++` versus `---` I don't *actually* know if the former is invalid or not, but I'm used to seeing `---` so I changed that to be safe.

Here's some example front-matter

```
$ cat content/posts/times-arrow.md
---
title: "Times Arrow"
date: "2020-03-13T09:46:32-04:00"
draft: true
author: 'Nick Dumas'
cover: ""
tags: ["", ""]
keywords: ["", ""]
description: ""
showFullContent : false
---
```