### PR TITLE
Only populate og:image with cover if is set

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -40,7 +40,15 @@
 <meta property="og:description" content="{{ if .IsHome }}{{ $.Site.Params.Subtitle }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:site_name" content="{{ .Title }}" />
-<meta property="og:image" content="{{ if .IsHome }}{{ $.Site.Params.favicon | absURL }}{{else}}{{ isset .Params "cover" | absURL }}{{ end }}">
+{{ if and (ne .IsHome) (isset .Params "cover") }}
+  <meta property="og:image" content="{{ .Param "cover" | absURL }}">
+{{ else }}
+  {{ if isset $.Site.Params "favicon" }}
+    <meta property="og:image" content="{{ $.Site.Params.favicon | absURL }}">
+  {{ else }}
+    <meta property="og:image" content="{{ printf "img/favicon/%s.png" $.Site.Params.ThemeColor | absURL }}">
+  {{ end }}
+{{ end }}
 <meta property="og:image:width" content="2048">
 <meta property="og:image:height" content="1024">
 {{ range .Params.categories }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -40,7 +40,7 @@
 <meta property="og:description" content="{{ if .IsHome }}{{ $.Site.Params.Subtitle }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:site_name" content="{{ .Title }}" />
-<meta property="og:image" content="{{ if .IsHome }}{{ $.Site.Params.favicon | absURL }}{{else}}{{ .Params.Cover | absURL }}{{ end }}">
+<meta property="og:image" content="{{ if .IsHome }}{{ $.Site.Params.favicon | absURL }}{{else}}{{ isset .Params "cover" | absURL }}{{ end }}">
 <meta property="og:image:width" content="2048">
 <meta property="og:image:height" content="1024">
 {{ range .Params.categories }}


### PR DESCRIPTION
Hi Radek

Apologies, I missed one item in the last PR!

At the moment `og:image` is being set with `.Params.Cover` for all posts, however if an image is not defined then `og:image` is getting the site/page URL instead of an image URL.  

I'm in two minds with this one:

1. Only show the post image when it is set (how this PR is currently configured) and no fallback
2. Show the site favicon as a fallback at _all times_ when a post image is not defined