### PR TITLE
Use description for og:description

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,7 +37,7 @@
 <meta property="og:locale" content="{{ $.Site.Language.Lang }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
 <meta property="og:title" content="{{ if .IsHome }}{{ $.Site.Title }}{{ else }}{{ .Title }} :: {{ $.Site.Title }}{{ end }}">
-<meta property="og:description" content="{{ if .IsHome }}{{ $.Site.Params.Subtitle }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
+<meta property="og:description" content="{{ if .IsHome }}{{ $.Site.Params.Subtitle }}{{ else if .Description}}{{ .Description | plainify }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
 <meta property="og:site_name" content="{{ .Title }}" />
 <meta property="og:image" content="{{ if .IsHome }}{{ $.Site.Params.favicon | absURL }}{{else}}{{ .Params.Cover | absURL }}{{ end }}">


### PR DESCRIPTION
Small bit of logic to use the Description of a post as the og:description in the head if it is set, else to use the summary.

Love the theme (https://blog.nebloc.com)! :smile: 