### PR TITLE
Don't truncate content in Firefox print preview

### DIFF
--- a/source/css/main.css
+++ b/source/css/main.css
@@ -254,10 +254,18 @@ ol ol {
   @media (--phone) {
     padding: 20px;
   }
+
+  @media print {
+    display: initial;
+  }
 }
 
 .content {
   display: flex;
+
+  @media print {
+    display: initial;
+  }
 }
 
 hr {


### PR DESCRIPTION
Fixes #135 