### PR TITLE
Hide header and pagination footer when printing

### DIFF
--- a/source/css/header.css
+++ b/source/css/header.css
@@ -15,6 +15,10 @@
   flex-direction: column;
   position: relative;
 
+  @media print {
+    display: none;
+  }
+
   &__inner {
     display: flex;
     align-items: center;

--- a/source/css/pagination.css
+++ b/source/css/pagination.css
@@ -1,6 +1,10 @@
 .pagination {
   margin-top: 50px;
 
+  @media print {
+    display: none;
+  }
+
   &__title {
     display: flex;
     text-align: center;


### PR DESCRIPTION
Since the header and pagination footer contain links that help a reader
navigate the site in a browser, they serve little value on a printed
copy.