### PR TITLE
Add color-per-page support

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,7 +9,9 @@
 
 <!-- Theme CSS -->
 <link rel="stylesheet" href="{{ "assets/style.css" | absURL }}">
-{{ if (ne $.Site.Params.ThemeColor "orange") }}
+{{ if (isset .Params "color") }}
+  <link rel="stylesheet" href="{{ (printf "assets/%s.css" .Params.color) | absURL }}">
+{{ else if (ne $.Site.Params.ThemeColor "orange") }}
   <link rel="stylesheet" href="{{ (printf "assets/%s.css" $.Site.Params.ThemeColor) | absURL }}">
 {{ end }}
 


### PR DESCRIPTION
This adds bits to check for a `color` param in a page's front-matter before going with the global theme.

Addresses #20 