### PR TITLE
Fix spacing in lists between :: and Author

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -24,7 +24,7 @@
             {{ .Date.Format "2006-01-02" }}
           </span>
           {{ with .Params.Author }}
-            <span class="post-author">::{{ . }}</span>
+            <span class="post-author">:: {{ . }}</span>
           {{ end }}
         </div>
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -15,7 +15,7 @@
             {{ .Date.Format "2006-01-02" }}
           </span>
           {{ with .Params.Author }}
-            <span class="post-author">::{{ . }}</span>
+            <span class="post-author">:: {{ . }}</span>
           {{ end }}
         </div>
 


### PR DESCRIPTION
In the post view, the line under the title rendered as:
```
2020-07-31 :: Author Name
```

On list views (tags) and homepage (index), it was displaying without a space before the author's name:
```
2020-07-31 ::Author Name
```

This PR unifies the spacing everywhere to look balanced & match the post view.
