### PR TITLE
Modernize apple-touch-icon

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -21,7 +21,7 @@
 {{- end }}
 
 <!-- Icons -->
-<link rel="apple-touch-icon-precomposed" sizes="144x144" href="{{ "img/apple-touch-icon-144-precomposed.png" | absURL }}">
+<link rel="apple-touch-icon" href="{{ "img/apple-touch-icon-192x192.png" | absURL }}">
 {{ if isset $.Site.Params "favicon" }}
   <link rel="shortcut icon" href="{{ $.Site.Params.favicon | absURL }}">
 {{ else }}


### PR DESCRIPTION
- `apple-touch-icon-precomposed` has been obsolete since iOS 7 [(source)](https://web.dev/apple-touch-icon/), replaced with `apple-touch-icon`
- updated image filename to suggest new dimensions
- remove unneccessary `sizes` in `<link>`