### PR TITLE
add wide width theme size

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,8 +113,9 @@ paginate = 5
   # show selector to switch language
   showLanguageSelector = false
 
-  # set theme to full screen width
-  fullWidthTheme = false
+  # set theme width full | wide | default
+  # full screen, wide (60%), default
+  themeWidth = "default"
 
   # center theme with default width
   centerTheme = false

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -304,8 +304,13 @@ mark {
     max-width: 100%;
   }
 
+  &.wide {
+    max-width: 60%;
+  }
+
   @media (--phone) {
     padding: 20px;
+    max-width: 100% !important;
   }
 
   @media print {

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -7,9 +7,10 @@
   {{ partial "head.html" . }}
 </head>
 <body class="{{- ( or .Params.color $.Site.Params.ThemeColor ) -}}">
-{{ $container := cond $.Site.Params.FullWidthTheme "container full" (cond $.Site.Params.CenterTheme "container center" "container") }}
+{{ $containerThemeWidth := cond (eq $.Site.Params.ThemeWidth "full") "container full" (cond (eq $.Site.Params.ThemeWidth "wide") "container wide" "container") }}
+{{ $containerThemeCenter :=  cond $.Site.Params.CenterTheme "center" "" }}
 
-<div class="{{- $container -}}{{- cond ($.Site.Params.oneHeadingSize | default true) " headings--one-size" "" }}">
+<div class="{{- $containerThemeWidth }} {{ $containerThemeCenter -}} {{- cond ($.Site.Params.oneHeadingSize | default true) " headings--one-size" "" }}">
 
   {{ partial "header.html" . }}
 


### PR DESCRIPTION
This adds an alternative page width size option of 'wide' which is 60% max width.

This replaces the ```fullWidthTheme``` param with ```themeWidth```, which accepts ```full``` or ```wide``` with any other value using the default.

I'm not sure if there is a more acceptable size that is larger than the default and smaller than the max, but 60% looks OK to me when eye-balling it.