### PR TITLE
Only add twitter card if twitter defined

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -29,11 +29,13 @@
 {{ end }}
 
 <!-- Twitter Card -->
+{{ if (isset $.Site.Params "twitter") }}
 <meta name="twitter:card" content="summary" />
-{{ if (isset $.Site.Params.Twitter "site") }}
-  <meta name="twitter:site" content="{{ $.Site.Params.Twitter.site }}" />
+  {{ if (isset $.Site.Params.Twitter "site") }}
+    <meta name="twitter:site" content="{{ $.Site.Params.Twitter.site }}" />
+  {{ end }}
+    <meta name="twitter:creator" content="{{ if .IsHome }}{{ $.Site.Params.Twitter.creator }}{{ else if isset .Params "authortwitter" }}{{ .Params.authorTwitter }}{{ else }}{{ .Params.Author }}{{ end }}" />
 {{ end }}
-<meta name="twitter:creator" content="{{ if .IsHome }}{{ $.Site.Params.Twitter.creator }}{{ else if isset .Params "authortwitter" }}{{ .Params.authorTwitter }}{{ else }}{{ .Params.Author }}{{ end }}" />
 
 <!-- OG data -->
 <meta property="og:locale" content="{{ $.Site.Language.Lang }}" />


### PR DESCRIPTION
Removes warning
`WARNING: calling IsSet with unsupported type "invalid" (<nil>) will always return false.`
in newer hugo versions when
```toml
[params.twitter]
```
is not defined.

An alternative would be to define an empty twitter param, but that will generate a superflous
```html
<meta name="twitter:card" content="summary" />
```