### PR TITLE
Ensure text remains visible during webfont load

### DIFF
--- a/assets/css/font.css
+++ b/assets/css/font.css
@@ -3,6 +3,7 @@
   font-style:  normal;
   font-weight: 400;
   src: url("../fonts/FiraCode-Regular.woff") format("woff");
+  font-display: swap;
 }
 
 @font-face {
@@ -10,4 +11,5 @@
   font-style:  normal;
   font-weight: 800;
   src: url("../fonts/FiraCode-Bold.woff") format("woff");
+  font-display: swap;
 }


### PR DESCRIPTION
Prevent text of being hidden until the font file is loaded as per this [recommendation](https://web.dev/font-display/?utm_source=lighthouse&utm_medium=devtools).