### PR TITLE
Improve Open Graph Tags

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -44,10 +44,10 @@
 <!-- OG data -->
 <meta property="og:locale" content="{{ $.Site.Language.Lang }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />
-<meta property="og:title" content="{{ if .IsHome }}{{ $.Site.Title }}{{ else }}{{ .Title }} :: {{ $.Site.Title }}{{ end }}">
+<meta property="og:title" content="{{ if .IsHome }}{{ $.Site.Title }}{{ else }}{{ .Title }}{{ end }}">
 <meta property="og:description" content="{{ if .IsHome }}{{ $.Site.Params.Subtitle }}{{ else if .Description}}{{ .Description | plainify }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
 <meta property="og:url" content="{{ .Permalink }}" />
-<meta property="og:site_name" content="{{ .Title }}" />
+<meta property="og:site_name" content="{{ $.Site.Title }}" />
 {{ if and (not .IsHome) (isset .Params "cover") }}
   <meta property="og:image" content="{{ .Param "cover" | absURL }}">
 {{ else }}


### PR DESCRIPTION
This pull-request proposes to change these Open-Graph tags to better follow the guidelines.

#### `og:title`: `.Title :: .$.Site.Title` to `.Title`

> og:title - The title of your object as it should appear within the graph, e.g., "The Rock".

#### `og:site_name`: `.Title` to `$.Site.Title`

> og:site_name - If your object is part of a larger web site, the name which should be displayed for the overall site. e.g., "IMDb".
