### PR TITLE
Hide the menu button on mobile if the menu is empty

### DIFF
--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -3,7 +3,9 @@
     <div class="header__logo">
       {{ partial "logo.html" . }}
     </div>
-    <div class="menu-trigger">menu</div>
+    {{ if len $.Site.Menus }}
+      <div class="menu-trigger">menu</div>
+    {{ end }}
   </div>
   {{ if len $.Site.Menus }}
     {{ partial "menu.html" . }}


### PR DESCRIPTION
This would fix my previously reported issue #197 