### PR TITLE
Single page website layout feature and add user

### DIFF
--- a/COMMUNITY-FEATURES.md
+++ b/COMMUNITY-FEATURES.md
@@ -19,3 +19,7 @@ eg:
 - **Portfolio** (https://github.com/Louisload/hugo-theme-terminal-portfolio)
   - Allows you to create a portfolio page (or several). Supports icons and subsections.
   - Luís Rodrigues Alves (Louisload), a game dev and musician.
+
+- **Single Page Website** (https://github.com/justinnuwin/hugo-theme-terminal)
+  - A layout where the homepage can render lists of pages and the navigation menu can link to sections on the homepage.
+  - Justin Nguyen, software and hardware developer.

--- a/USERS.md
+++ b/USERS.md
@@ -48,6 +48,7 @@
 - https://mcwertgaming.github.io **Damon Leven** (Student & Software Developer)
 - https://sethsimmons.me **Seth Simmons** (Information Security Engineer, Cryptocurrency Writer)
 - https://thesprawl.city **crish** (Software and stuff)
+- https://justinnuwin.com **Justin Nguyen** (Software & Hardware Developer)
 
 <!--
  TEMPLATE:


### PR DESCRIPTION
New PR replacing #232 which updates the community feature file. I add myself to the users list too 😎

tl;dr of #232 This feature implements
- Add support for homepage sections as its own archetype
- Homepage rendering is controlled by the navigation bar settings and ordering (if the nav bar links to a lists-page a shorter page listing will be rendered on the homepage, same with taxonomy pages, etc.)

I am currently running my fork with these changes on my [personal website](https://justinnuwin.com).