### PR TITLE
word count & min read added

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -10,7 +10,9 @@
     {{ end }}
     {{ with .Params.Author }}
     <span class="post-author">:: {{ . }}</span>
-    {{ end }}
+    {{ end }} ::
+    {{ .WordCount }} words ::
+    {{ .ReadingTime }} min read
   </div>
 
   {{ if .Params.tags }}


### PR DESCRIPTION
I've added word count and reading time. They will appear after author name or date if author is not defined in front matter.