### PR TITLE
Use Page Bundles, automatically use cover file if available.

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -39,17 +39,8 @@
         {{ end }}
 
 
-        {{- $cover := false -}}
-        {{- $autoCover := default $.Site.Params.autoCover false }}
-        {{- if $autoCover -}}
-          {{- $cover = .Resources.GetMatch "cover.*" -}}
-        {{- else if .Params.Cover -}}
-          {{- if .Resources.GetMatch .Params.Cover }}
-            {{ $cover = .Resources.GetMatch .Params.Cover }}
-          {{- end -}}
-        {{- end -}}
-        {{if $cover -}} <img src="{{ $cover.Permalink }}" class="post-cover" alt="{{ .Title | plainify | default " " }}" />{{- end }}
-      
+        {{ partial "cover.html" . }}
+
 
         <div class="post-content">
           {{ if .Params.showFullContent }}

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -38,9 +38,18 @@
           </span>
         {{ end }}
 
-        {{ if .Params.Cover }}
-          <img src="{{ .Params.Cover | absURL }}" class="post-cover" alt="{{ .Title | plainify | default " " }}" />
-        {{ end }}
+
+        {{- $cover := false -}}
+        {{- $autoCover := default $.Site.Params.autoCover false }}
+        {{- if $autoCover -}}
+          {{- $cover = .Resources.GetMatch "cover.*" -}}
+        {{- else if .Params.Cover -}}
+          {{- if .Resources.GetMatch .Params.Cover }}
+            {{ $cover = .Resources.GetMatch .Params.Cover }}
+          {{- end -}}
+        {{- end -}}
+        {{if $cover -}} <img src="{{ $cover.Permalink }}" class="post-cover" alt="{{ .Title | plainify | default " " }}" />{{- end }}
+      
 
         <div class="post-content">
           {{ if .Params.showFullContent }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -29,17 +29,8 @@
           </span>
         {{ end }}
 
+        {{ partial "cover.html" . }}
 
-        {{- $cover := false -}}
-        {{- $autoCover := default $.Site.Params.autoCover false }}
-        {{- if $autoCover -}}
-          {{- $cover = .Resources.GetMatch "cover.*" -}}
-        {{- else if .Params.Cover -}}
-          {{- if .Resources.GetMatch .Params.Cover }}
-            {{ $cover = .Resources.GetMatch .Params.Cover }}
-          {{- end -}}
-        {{- end -}}
-        {{if $cover -}} <img src="{{ $cover.Permalink }}" class="post-cover" alt="{{ .Title | plainify | default " " }}" />{{- end }}
       
         <div class="post-content">
           {{ if .Params.showFullContent }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -29,10 +29,18 @@
           </span>
         {{ end }}
 
-        {{ if .Params.Cover }}
-          <img src="{{ .Params.Cover | absURL }}" class="post-cover" alt="{{ .Title | plainify | default " " }}" />
-        {{ end }}
 
+        {{- $cover := false -}}
+        {{- $autoCover := default $.Site.Params.autoCover false }}
+        {{- if $autoCover -}}
+          {{- $cover = .Resources.GetMatch "cover.*" -}}
+        {{- else if .Params.Cover -}}
+          {{- if .Resources.GetMatch .Params.Cover }}
+            {{ $cover = .Resources.GetMatch .Params.Cover }}
+          {{- end -}}
+        {{- end -}}
+        {{if $cover -}} <img src="{{ $cover.Permalink }}" class="post-cover" alt="{{ .Title | plainify | default " " }}" />{{- end }}
+      
         <div class="post-content">
           {{ if .Params.showFullContent }}
           {{ .Content | markdownify }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -21,9 +21,16 @@
   </span>
   {{ end }}
 
-  {{ if .Params.Cover }}
-    <img src="{{ .Params.Cover | absURL }}" class="post-cover" alt="{{ .Title | plainify | default " " }}" />
-  {{ end }}
+  {{- $cover := false -}}
+  {{- $autoCover := default $.Site.Params.autoCover false }}
+  {{- if $autoCover -}}
+    {{- $cover = .Resources.GetMatch "cover.*" -}}
+  {{- else if .Params.Cover -}}
+    {{- if .Resources.GetMatch .Params.Cover }}
+      {{ $cover = .Resources.GetMatch .Params.Cover }}
+    {{- end -}}
+  {{- end -}}
+  {{if $cover -}} <img src="{{ $cover.Permalink }}" class="post-cover" alt="{{ .Title | plainify | default " " }}" />{{- end }}
 
   {{ if .Params.Toc }}
     <div class="table-of-contents">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -20,17 +20,7 @@
     {{ end }}
   </span>
   {{ end }}
-
-  {{- $cover := false -}}
-  {{- $autoCover := default $.Site.Params.autoCover false }}
-  {{- if $autoCover -}}
-    {{- $cover = .Resources.GetMatch "cover.*" -}}
-  {{- else if .Params.Cover -}}
-    {{- if .Resources.GetMatch .Params.Cover }}
-      {{ $cover = .Resources.GetMatch .Params.Cover }}
-    {{- end -}}
-  {{- end -}}
-  {{if $cover -}} <img src="{{ $cover.Permalink }}" class="post-cover" alt="{{ .Title | plainify | default " " }}" />{{- end }}
+  {{ partial "cover.html" . }}
 
   {{ if .Params.Toc }}
     <div class="table-of-contents">

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -1,12 +1,16 @@
 {{- $cover := false -}}
 {{- $autoCover := default $.Site.Params.autoCover false }}
-{{- if $autoCover -}}
-  {{- $cover = (.Resources.GetMatch "cover.*").RelPermalink -}}
-{{- else if .Params.Cover -}}
+{{- if index .Params "cover" -}}
   {{- if .Resources.GetMatch .Params.Cover }}
     {{- $cover = (.Resources.GetMatch .Params.Cover).RelPermalink -}}
   {{- else -}}
     {{- $cover = absURL .Params.Cover -}}
+  {{- end -}}
+{{- else if $.Site.Params.AutoCover -}}
+  {{- if and ( index .Params "cover" ) (not .Params.Cover) -}}
+  {{- if .Resources.GetMatch "cover.*" -}}
+    {{- $cover = (.Resources.GetMatch "cover.*").RelPermalink -}}
+  {{- end -}}
   {{- end -}}
 {{- end -}}
 {{if $cover -}}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -11,5 +11,8 @@
 {{- end -}}
 {{if $cover -}}
   <!-- Cover image found -->
-  <img src="{{ $cover }}" class="post-cover" alt="{{ .Title | plainify | default " " }}" />
+  <img src="{{ $cover }}"
+    class="post-cover"
+    alt="{{ .Title | plainify | default " " }}"
+    title="{{ .Params.CoverCredit |plainify|default "Cover Image" }}" />
 {{- end }}

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -1,0 +1,15 @@
+{{- $cover := false -}}
+{{- $autoCover := default $.Site.Params.autoCover false }}
+{{- if $autoCover -}}
+  {{- $cover = (.Resources.GetMatch "cover.*").RelPermalink -}}
+{{- else if .Params.Cover -}}
+  {{- if .Resources.GetMatch .Params.Cover }}
+    {{- $cover = (.Resources.GetMatch .Params.Cover).RelPermalink -}}
+  {{- else -}}
+    {{- $cover = absURL .Params.Cover -}}
+  {{- end -}}
+{{- end -}}
+{{if $cover -}}
+  <!-- Cover image found -->
+  <img src="{{ $cover }}" class="post-cover" alt="{{ .Title | plainify | default " " }}" />
+{{- end }}


### PR DESCRIPTION
This change fixes #249 and introduces the feature that I asked for.

I don't know if this affects people who are using `static` or other means of setting up cover images. It could easily be gated behind another parameter, or logic extended a bit. 

This should probably be turned into a partial, as the logic is getting slightly more and more complex. 

--

Closes #249, #274