### PR TITLE
Enable installation as a Hugo Module

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/panr/hugo-theme-terminal
+
+go 1.15


### PR DESCRIPTION
### Specific description of go.mod file:

Define this module by linking to its repo (panr's) and stating a minimum required version of go.

### Purpose:

I believe this file is all that's needed to let users install this theme as a Hugo Module. I'm new to this so please double-check!

Installing it as a Hugo Module means the user can avoid using git clone (doesn't work with Netlify) or git submodule (which apparently should work with Netlify, but didn't work for me after hours of attempts).

It also looks like the future trend, but all things change.

### Risks:

When a user is installing this theme as a Hugo Module, they need to require a specific release version or tag. I don't know why, but this can be a bit finnicky and is worth experimenting with.

### Working example:

As well as this fork, I have also copied my fork to a new repo - https://github.com/kdmcguire/hugo-theme-terminal-hugo-module - so that I could set my own module repo link without disrupting the PR here.

This is used by my hugo site at https://github.com/kdmcguire/kieran-mcguire, specifically by creating my own Hugo Module and requiring the theme in https://github.com/kdmcguire/kieran-mcguire/blob/main/go.mod

```go
module github.com/kdmcguire/kieran-mcguire

go 1.15

require github.com/kdmcguire/hugo-theme-terminal-hugo-module v1.0.0 // indirect

```

And then setting the theme in https://github.com/kdmcguire/kieran-mcguire/blob/main/config.toml

```go
theme = "github.com/kdmcguire/hugo-theme-terminal-hugo-module"

[module]
  [[module.imports]]
    path = "github.com/kdmcguire/hugo-theme-terminal-hugo-module"
    disabled = "false"
```

This produces this working Netlify site: https://kieran-mcguire.netlify.app/