### PR TITLE
Make prismjs shortcode CRLF tolerant

### DIFF
--- a/layouts/shortcodes/prismjs.html
+++ b/layouts/shortcodes/prismjs.html
@@ -1,4 +1,4 @@
-{{ $inner := replaceRE "^\n" "" .Inner | string }}
+{{ $inner := replaceRE "^\r?\n" "" .Inner | string }}
 {{ if len .Params | eq 0 }}
   <pre><code>{{ $inner }}</code></pre>
 {{ else }}


### PR DESCRIPTION
An extra line kept appearing at the start of a prismjs block. It appears that the code responsible, line 1, only checked for `\n`, when the new line is saved as a `\r\n` on a windows system (apparently VSCode defaults to CRLF line endings).
This checks for both, fixing the issue.