### PR TITLE
markdownify on  .Content not needed

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -44,7 +44,7 @@
 
         <div class="post-content">
           {{ if .Params.showFullContent }}
-          {{ .Content | markdownify }}
+          {{ .Content }}
           {{ else if .Description }}
           {{ .Description | markdownify }}
           {{ else }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -35,7 +35,7 @@
 
         <div class="post-content">
           {{ if .Params.showFullContent }}
-          {{ .Content | markdownify }}
+          {{ .Content }}
           {{ else if .Description }}
           {{ .Description | markdownify }}
           {{ else }}


### PR DESCRIPTION
No need to markdownify .Content, per Hugo project (https://github.com/gohugoio/hugo/      issues/2616#issuecomment-255179057). This fixes issues with showFullContent and the current version of Hugo (there is an issue here as well https://github.com/gohugoio/hugo/issues/7372)
