### PR TITLE
fixed post-content logic in index.html and list.html

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -44,13 +44,11 @@
 
         <div class="post-content">
           {{ if .Params.showFullContent }}
-          {{ .Content }}
+            {{ .Content }}
           {{ else if .Description }}
-          {{ .Description | markdownify }}
+            {{ .Description | markdownify }}
           {{ else }}
-          {{ if .Truncated }}
-          {{ .Summary }}
-          {{ end }}
+            {{ .Summary | markdownify }}
           {{ end }}
         </div>
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -34,13 +34,11 @@
       
         <div class="post-content">
           {{ if .Params.showFullContent }}
-          {{ .Content }}
+            {{ .Content }}
           {{ else if .Description }}
-          {{ .Description | markdownify }}
+            {{ .Description | markdownify }}
           {{ else }}
-          {{ if .Truncated }}
-          {{ .Summary }}
-          {{ end }}
+            {{ .Summary | markdownify }}
           {{ end }}
         </div>
 


### PR DESCRIPTION
If `.Params.showFullContent == false` and `.Description == false` (it was not set in the front matter), then `summary` should be used regardless of `.Truncated`.
For example, if `summary` was explicitly inserted in the front matter, then `.Truncated` is false. 
With the previous code, if `summary` is present in the front matter, but `description` is not, nothing is shown below the post title.
With this fix, the explicitly created `summary` is used.