### PR TITLE
document `Toc`, `TocTitle` & `readingTime`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,12 +32,18 @@
 
 #### Built-in shortcodes
 
-- **`image`** (prop required: **`src`**; props optional: **`alt`**, **`position`** (**left** is default | center | right), **`style`**)
-  - eg: `{{< image src="/img/hello.png" alt="Hello Friend" position="center" style="border-radius: 8px;" >}}`
+- **`image`** (props required: **`src`**; props optional: **`alt`**, **`position`** (**left** is default | center | right), **`style`**)
+  - e.g.
+  ```go
+  {{< image src="/img/hello.png" alt="Hello Friend" position="center" style="border-radius: 8px;" >}}
+  ```
 - **`figure`** (same as `image`, plus few optional props: **`caption`**, **`captionPosition`** (left | **center** is default | right), **`captionStyle`**)
-  - eg: `{{< figure src="/img/hello.png" alt="Hello Friend" position="center" style="border-radius: 8px;" caption="Hello Friend!" captionPosition="right" captionStyle="color: red;" >}}`
-- **`code`** (prop required: **`language`**; props optional: **`title`**, **`id`**, **`expand`** (default "△"), **`collapse`** (default "▽"), **`isCollapsed`**)
-  - eg:
+  - e.g.
+  ```go
+  {{< figure src="/img/hello.png" alt="Hello Friend" position="center" style="border-radius: 8px;" caption="Hello Friend!" captionPosition="right" captionStyle="color: red;" >}}
+  ```
+- **`code`** (props required: **`language`**; props optional: **`title`**, **`id`**, **`expand`** (default "△"), **`collapse`** (default "▽"), **`isCollapsed`**)
+  - e.g.
   ```go
   {{< code language="css" title="Really cool snippet" id="1" expand="Show" collapse="Hide" isCollapsed="true" >}}
   pre {
@@ -148,8 +154,18 @@ paginate = 5
   # updatedDatePrefix = "Updated"
 
   # set all headings to their default size (depending on browser settings)
-  # it's set to `true` by default
-  # oneHeadingSize = false
+  # oneHeadingSize = true # default
+
+  # whether to show a page's estimated reading time
+  # readingTime = false # default
+
+  # whether to show a table of contents
+  # can be overridden in a page's front-matter
+  # Toc = false # default
+
+  # set title for the table of contents
+  # can be overridden in a page's front-matter
+  # TocTitle = "Table of Contents" # default
 
 
 [params.twitter]

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -28,16 +28,10 @@
   {{ end }}
   {{ partial "cover.html" . }}
 
-  {{ if .Params.Toc }}
+  {{ if (.Params.Toc | default .Site.Params.Toc) }}
     <div class="table-of-contents">
       <h2>
-        {{ if .Params.TocTitle }}
-          {{ .Params.TocTitle }}
-        {{ else if $.Site.Params.TocTitle }}
-          {{ $.Site.Params.TocTitle }}
-        {{ else }}
-          Table of Contents
-        {{ end }}
+        {{ (.Params.TocTitle | default .Site.Params.TocTitle) | default "Table of Contents" }}
       </h2>
       {{ .TableOfContents }}
     </div>


### PR DESCRIPTION
As discussed in #313,
- added `Toc`, `TocTitle` and `readingTime` params to the sample config in the main readme
- changed formatting of shortcode examples to code blocks in the readme
- made `Toc` a site-wide param, similar to `TocTitle` (in the `single.html` layout)
- removed redundant `if` statements from the `single.html` layout