### PR TITLE
Added dateFormat parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,9 @@ paginate = 5
   # With this option you don't have to put the `cover` param in a front-matter.
   autoCover = true
 
+  # Provide a string as a date format. By default, 2006-01-02. See https://pkg.go.dev/github.com/vigneshuvi/GoDateFormat "Constants and Placeholders" for more information.
+  dateFormat = "01-02-2006"
+
   # set post to show the last updated
   # If you use git, you can set `enableGitInfo` to `true` and then post will automatically get the last updated
   showLastUpdated = false

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -9,6 +9,7 @@ paginate = 5
   showMenuItems = 2
   fullWidthTheme = false
   centerTheme = false
+  dateFormat = "2006-01-02"
 
 [languages]
   [languages.en]

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -21,7 +21,7 @@
         </h1>
         <div class="post-meta">
           <span class="post-date">
-            {{ .Date.Format "2006-01-02" }}
+            {{ .Date.Format $.Site.Params.dateFormat }}
           </span>
           {{ with .Params.Author }}
             <span class="post-author">:: {{ . }}</span>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -12,7 +12,7 @@
         </h1>
         <div class="post-meta">
           <span class="post-date">
-            {{ .Date.Format "2006-01-02" }}
+            {{ .Date.Format $.Site.Params.dateFormat }}
           </span>
           {{ with .Params.Author }}
             <span class="post-author">:: {{ . }}</span>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -5,9 +5,9 @@
   <div class="post-meta">
     {{ if .Params.Date }}
       <span class="post-date">
-        {{ .Date.Format "2006-01-02" }}
+        {{ .Date.Format $.Site.Params.dateFormat }}
         {{ if $.Site.Params.showLastUpdated }}
-          [{{or $.Site.Params.updatedDatePrefix "Updated"}}: {{ .Lastmod.Format "2006-01-02" }}]
+          [{{or $.Site.Params.updatedDatePrefix "Updated"}}: {{ .Lastmod.Format $.Site.Params.dateFormat }}]
         {{ end }}
       </span>
     {{ end }}


### PR DESCRIPTION
Added new dateFormat param and set visible dates to reference it. Defaults to existing format: 2006-01-02. I could also imagine this being extended to languages, enabling more advanced format specification per-language. I hope this is helpful.