### PR TITLE
Adds flag to hide comments on a page-to-page basis

### DIFF
--- a/archetypes/posts.md
+++ b/archetypes/posts.md
@@ -9,4 +9,5 @@ keywords = ["", ""]
 description = ""
 showFullContent = false
 readingTime = false
+hideComments = false
 +++

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -49,6 +49,8 @@
   {{ partial "posts_pagination.html" . }}
   {{ end }}
 
+  {{ if not (.Params.hideComments | default false) }}
   {{ partial "comments.html" . }}
+  {{ end }}
 </div>
 {{ end }}


### PR DESCRIPTION
I noticed that comments are visible on all pages. On some pages however it's nice to disable comments, like an about page.