### PR TITLE
Don't markdownify `.Summary`

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -38,7 +38,7 @@
           {{ else if .Description }}
             {{ .Description | markdownify }}
           {{ else }}
-            {{ .Summary | markdownify }}
+            {{ .Summary }}
           {{ end }}
         </div>
 


### PR DESCRIPTION
When a post defines a custom summary through `<!--more-->` tag,
`markdownify` does not work and results in the post having empty summary.

This fixes the behavior to render it properly.