### PR TITLE
Fix list date shown as 0001-01-01 when not set

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -20,9 +20,11 @@
           <a href="{{ .Permalink }}">{{ .Title | markdownify }}</a>
         </h1>
         <div class="post-meta">
+          {{- with .Date }}
           <span class="post-date">
-            {{ .Date.Format "2006-01-02" }}
+            {{ .Format "2006-01-02" }}
           </span>
+          {{- end }}
           {{ with .Params.Author }}
             <span class="post-author">:: {{ . }}</span>
           {{ end }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -11,9 +11,11 @@
           <a href="{{ .Permalink }}">{{ .Title | markdownify }}</a>
         </h1>
         <div class="post-meta">
+        {{- with .Date }}
           <span class="post-date">
-            {{ .Date.Format "2006-01-02" }}
+            {{ .Format "2006-01-02" }}
           </span>
+        {{- end }}
           {{ with .Params.Author }}
             <span class="post-author">:: {{ . }}</span>
           {{ end }}


### PR DESCRIPTION
https://github.com/panr/hugo-theme-terminal/pull/52 fixed the date rendering as `0001-01-01` on a specific page, but dates still show incorrectly in the list layout. This PR hides the date so that the list layout behaves like the single layout.