### PR TITLE
Add beside menu entry after main in menu partial

### DIFF
--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -26,6 +26,9 @@
         {{ end }}
       {{ end }}
     {{ end }}
+    {{ range $.Site.Menus.beside }}
+        <li><a href="{{ .URL }}">{{ .Name }}</a></li>
+    {{ end }}
 
     {{ if and $.Site.Params.showLanguageSelector (len $.Site.Home.AllTranslations) }}
     <div class="spacer"></div>
@@ -47,6 +50,9 @@
       {{ if not .HasChildren }}
         <li><a href="{{ .URL }}">{{ .Name }}</a></li>
       {{ end }}
+    {{ end }}
+    {{ range $.Site.Menus.beside }}
+        <li><a href="{{ .URL }}">{{ .Name }}</a></li>
     {{ end }}
     {{ if and $.Site.Params.showLanguageSelector (len $.Site.Home.AllTranslations) }}
     <hr />


### PR DESCRIPTION
Hi. hugo menus are sorted by it's visible name in order.
but sometime we need a change this order.

I hope the menu identifier do this works... (I m not ready code go lang)

I made a change this into terminal theme.

![image](https://user-images.githubusercontent.com/906974/178086336-b49771d1-6786-4300-833c-56ac656d5ee4.png)

In this case I want to move blog menu at last one. then I use config.toml in hugo, add this.

```toml
    [languages.en.menu]
      [[languages.en.menu.main]]
      // ... several main menus
      [[languages.en.menu.beside]]
        identifier = "blog"
        name = "Blog"
        url = "/en/blog"
```

![image](https://user-images.githubusercontent.com/906974/178086373-38d85dd1-10c6-4d6b-b9fc-82cba5d63240.png)

I can get this ordered menus. In narrow view page like this.

![image](https://user-images.githubusercontent.com/906974/178086384-fae28b57-f7a3-4a7a-a4f4-afd6eb17bcfd.png)

Did I make a change not a proper terminal theme's rule?

Thanks cool theme u gave us.