### PR TITLE
Allow language menu to be displayed at the side rather than below the menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,9 @@ paginate = 5
   # show selector to switch language
   showLanguageSelector = false
 
+  # show language menu at the side of the menu rather than below
+  # LanguageMenuLevel = 0
+
   # set theme to full screen width
   fullWidthTheme = false
 

--- a/layouts/partials/menu.html
+++ b/layouts/partials/menu.html
@@ -29,8 +29,13 @@
         {{ end }}
       {{ end }}
     {{ end }}
+  {{ if eq $.Site.Params.LanguageMenuLevel 0 }}
+  <span class="spacer"></span>
+  <li>
+  {{ else }}
   </ul>
   <span class="spacer"></span>
+  {{ end }}
   <ul class="menu__inner menu__inner--desktop">
     {{ if and $.Site.Params.showLanguageSelector (len $.Site.Home.AllTranslations) }}
     <li>
@@ -49,6 +54,10 @@
     </li>
     {{ end }}
   </ul>
+  {{ if eq $.Site.Params.LanguageMenuLevel 0 }}
+  </li>
+  </ul>
+  {{ end }}
 
   <ul class="menu__inner menu__inner--mobile">
     {{ range $.Site.Menus.main }}


### PR DESCRIPTION
Thanks for accepting my previous pull request. The menu partial was further changed in a way that it displays below the normal menu, which in my page didn't look good, so I added an option to display it at the same level with an option name that might allow for future ideas for different levels.
After pull:
![image](https://user-images.githubusercontent.com/69077/200167818-5487f212-8dd1-4896-96a1-963561131140.png)

After this change I propose with the param defined:
![image](https://user-images.githubusercontent.com/69077/200169170-a7df63cb-a038-4a17-a644-3c4bfb28618a.png)

Without the parameter defined with value 0, the first image is the default behavior.