### PR TITLE
#389 Added additional check if color param is empty string

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -9,7 +9,7 @@
 
 {{ $defaultStyles := resources.Get "css/style.scss" }}
 <!-- Local Theme Variables -->
-{{ if (isset .Params "color") }}
+{{ if and (isset .Params "color") (not (eq .Params.color "")) }}
   {{ $localColorCss := resources.Get (printf "css/color/%s.scss" .Params.color) }}
   {{ $localCss := slice $localColorCss $defaultStyles | resources.Concat (printf "css/%s-local.scss" .Params.color) }}
   {{ $localColorStyles := $localCss | resources.ToCSS }}


### PR DESCRIPTION
**Background**
When adding a new page, by default Hugo puts the parameter 'color' as an empty string:

`color = "" #color from the theme settings`

**Issue**
.Params.color is not checked for empty value, but later used to form a path to .scss file
