### PR TITLE
Improvements for Twitter cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ paginate = 5
 [params.twitter]
   # set Twitter handles for Twitter cards
   # see https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started#card-and-content-attribution
-  # do not include @
+  # include @
   creator = ""
   site = ""
 

--- a/README.md
+++ b/README.md
@@ -214,6 +214,10 @@ paginate = 5
   # include @
   creator = ""
   site = ""
+  # set Twitter card type for Twitter cards
+  # see https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started#started
+  # default value is "summary"
+  card_type = "summary"
 
 [languages]
   [languages.en]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,8 +37,8 @@
 {{ end }}
 
 <!-- Twitter Card -->
-{{ if (isset $.Site.Params.Twitter "content") }}
-  <meta name="twitter:card" content="{{ $.Site.Params.Twitter.content }}" />
+{{ if (isset $.Site.Params.Twitter "card_type") }}
+  <meta name="twitter:card" content="{{ $.Site.Params.Twitter.card_type }}" />
 {{ else }}
   <meta name="twitter:card" content="summary" />
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -37,7 +37,11 @@
 {{ end }}
 
 <!-- Twitter Card -->
-<meta name="twitter:card" content="summary" />
+{{ if (isset $.Site.Params.Twitter "content") }}
+  <meta name="twitter:card" content="{{ $.Site.Params.Twitter.content }}" />
+{{ else }}
+  <meta name="twitter:card" content="summary" />
+{{ end }}
 {{ if (isset $.Site.Params "twitter") }}
   {{ if (isset $.Site.Params.Twitter "site") }}
     <meta name="twitter:site" content="{{ $.Site.Params.Twitter.site }}" />


### PR DESCRIPTION
- In README, it was said not to include **@** for **creator** and **site** under params.twitter in config file, although it is said otherwise in [Twitter docs](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/guides/getting-started#card-and-content-attribution)
- **card_type** parameter can be specified under params.twitter in config file, especially useful for those who want to use "summary_large_image" for larger preview images in Twitter.