### PR TITLE
Add required version to config

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,4 @@
+[module]
+  [module.hugoVersion]
+    extended = true
+    min = '0.90.0'


### PR DESCRIPTION
This should generate a warning from hugo if using the standard build, or an old one.