### PR TITLE
Add an optional verification link to your Mastodon profile

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,6 +215,10 @@ paginate = 5
   creator = ""
   site = ""
 
+[params.mastodon]
+  # set rel-Link to your mastodon profile
+  # site = "" # full URL, e.g. https://myInstance.org/@myUsername
+  
 [languages]
   [languages.en]
     languageName = "English"

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -45,6 +45,11 @@
     <meta name="twitter:creator" content="{{ if .IsHome }}{{ $.Site.Params.Twitter.creator }}{{ else if isset .Params "authortwitter" }}{{ .Params.authorTwitter }}{{ else }}{{ .Params.Author }}{{ end }}" />
 {{ end }}
 
+<!-- Mastodon rel link -->
+{{ if (isset $.Site.Params.Mastodon "site") }}
+<link rel="me" href="{{ $.Site.Params.Mastodon.site }}" />
+{{ end }}
+
 <!-- OG data -->
 <meta property="og:locale" content="{{ $.Site.Language.Lang }}" />
 <meta property="og:type" content="{{ if .IsPage }}article{{ else }}website{{ end }}" />


### PR DESCRIPTION
Mastodon allows verification of links with <link rel="me" href="https://instacename.tld/@username">. Added this option to metadata in the head and the configuration example in readme