### PR TITLE
option to write the reading time in the same language as the site

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,6 +230,8 @@ paginate = 5
     olderPosts = "Older posts"
     missingContentMessage = "Page not found..."
     missingBackButtonLabel = "Back to home page"
+	minuteReadingTime = "min read"
+	words = "words"
 
     [languages.en.params.logo]
       logoText = "Terminal"

--- a/README.md
+++ b/README.md
@@ -230,8 +230,8 @@ paginate = 5
     olderPosts = "Older posts"
     missingContentMessage = "Page not found..."
     missingBackButtonLabel = "Back to home page"
-	minuteReadingTime = "min read"
-	words = "words"
+    minuteReadingTime = "min read"
+    words = "words"
 
     [languages.en.params.logo]
       logoText = "Terminal"

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -16,7 +16,7 @@
       <span class="post-author">{{ . }}</span>
     {{ end }}
     {{ if and (.Param "readingTime") (eq (.Param "readingTime") true) }}
-      <span class="post-reading-time">:: {{ .ReadingTime }} min read ({{ .WordCount }} words)</span>
+      <span class="post-reading-time">:: {{ .ReadingTime }} {{ $.Site.Params.minuteReadingTime | default "min read" }} ({{ .WordCount }} {{ $.Site.Params.words | default "words" }})</span>
     {{ end }}
   </div>
 


### PR DESCRIPTION
the string for the reading time is only available in english. With this PR, you can add the string in the same language as the site.