### PR TITLE
fix summary not showing

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -49,7 +49,7 @@
           {{ else if .Description }}
             {{ .Description | markdownify }}
           {{ else }}
-            {{ .Summary | markdownify }}
+            {{ .Summary }}
           {{ end }}
         </div>
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -39,7 +39,7 @@
           {{ else if .Description }}
             {{ .Description | markdownify }}
           {{ else }}
-            {{ .Summary | markdownify }}
+            {{ .Summary }}
           {{ end }}
         </div>
 


### PR DESCRIPTION
I found summary defined by adding a `<!--more-->` commentary is not showing.

This MR fixes this issue.

It seems that .Summary is already rendered by `hugo`.

```
$ hugo version
'hugo v0.109.0+extended linux/amd64 BuildDate=unknown
```