### PR TITLE
add an option to disable web fonts

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,8 @@ paginate = 5
   # TocTitle = "Table of Contents" # default
 
   # whether to disable FiraCode webfonts and reduce a little bit roading time
-  # noFont = flase # default
+  # noFont = false # default
+
 
 [params.twitter]
   # set Twitter handles for Twitter cards

--- a/README.md
+++ b/README.md
@@ -207,6 +207,8 @@ paginate = 5
   # can be overridden in a page's front-matter
   # TocTitle = "Table of Contents" # default
 
+  # whether to disable FiraCode webfonts and reduce a little bit roading time
+  # noFont = flase # default
 
 [params.twitter]
   # set Twitter handles for Twitter cards

--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -1,6 +1,5 @@
 @import "variables";
 
-@import "font";
 @import "buttons";
 @import "form";
 

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -13,16 +13,20 @@
 {{ template "_internal/google_analytics.html" . }}
 
 {{ $defaultStyles := resources.Get "css/style.scss" }}
+{{ $fontCss := resources.Get "css/font.scss" }}
+{{ if $.Site.Params.noFont }}
+  {{ $fontCss = resources.Get "css/nil.scss" }}
+{{ end}}
 <!-- Local Theme Variables -->
 {{ if and (isset .Params "color") (not (eq .Params.color "")) }}
   {{ $localColorCss := resources.Get (printf "css/color/%s.scss" .Params.color) }}
-  {{ $localCss := slice $localColorCss $defaultStyles | resources.Concat (printf "css/%s-local.scss" .Params.color) }}
+  {{ $localCss := slice $localColorCss $fontCss $defaultStyles | resources.Concat (printf "css/%s-local.scss" .Params.color) }}
   {{ $localColorStyles := $localCss | resources.ToCSS }}
   <link rel="stylesheet" href="{{ $localColorStyles.Permalink }}">
 {{ else }}
   <!-- Theme Variables -->
   {{ $colorCss := resources.Get (printf "css/color/%s.scss" ($.Site.Params.ThemeColor | default "orange")) }}
-  {{ $css := slice $colorCss $defaultStyles | resources.Concat "css/base.scss" }}
+  {{ $css := slice $colorCss $fontCss $defaultStyles | resources.Concat "css/base.scss" }}
   {{ $options := (dict "targetPath" "styles.css" "outputStyle" "compressed" "enableSourceMap" true "precision" 6 "includePaths" (slice "node_modules")) }}
   {{ $styles := $css | resources.ToCSS $options }}
   <link rel="stylesheet" href="{{ $styles.Permalink }}">


### PR DESCRIPTION
Add an option to reduce a bit page loading time by remove web fonts.

Example site config

```toml
[params]
  # ...
  noFont = true
```

This option will not change the font-family setting.
Pages will load local FiraCode font if possible. 