### PR TITLE
set text-align to justify for CJK languages

### DIFF
--- a/assets/css/post.scss
+++ b/assets/css/post.scss
@@ -25,6 +25,12 @@
   margin: 20px auto;
   padding: 20px 0;
 
+  p:lang(zh),
+  p:lang(ja),
+  p:lang(ko) {
+    text-align: justify;
+  }
+
   &:not(:last-of-type) {
     border-bottom: 1px solid $border-color;
   }


### PR DESCRIPTION
Default text-align is left.
For CJK languages, it's better to set the text-align to justify, which will align texts to both left and right.

> When the text-align property is set to "justify", each line is stretched so that every line has equal width, and the left and right margins are straight (like in magazines and newspapers) [ref](https://www.w3schools.com/css/css_text_align.asp)