### PR TITLE
Adds weight to config.toml example

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,10 +242,16 @@ paginate = 5
         identifier = "about"
         name = "About"
         url = "/about"
+
+        # The menu items are ordered alphabetically if no weight is provided.
+        # Otherwise, the menu items are ordered by weight from lowest to highest.
+        weight = 1
+        
       [[languages.en.menu.main]]
         identifier = "showcase"
         name = "Showcase"
         url = "/showcase"
+        weight = 2
 
 [module]
   # In case you would like to make changes to the theme and keep it locally in you repository,


### PR DESCRIPTION
Discovering how to arrange menu items in a non-alphabetic order can be challenging, as evidenced by issues #55, #147, and #272. This pull request addresses this issue by adding the `weight` property to the sample `config.toml`, making it easier for users to find the solution without having to search through the issues.