### PR TITLE
Fix reference to "framed" parameter

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
   {{ if .Content }}
-    <div class="index-content {{ if .Params.framed -}}framed{{- end -}}">
+    <div class="index-content {{ if $.Site.Params.framed -}}framed{{- end -}}">
       {{ .Content }}
     </div>
   {{ end }}


### PR DESCRIPTION
Previously, `layouts/_default/index.html` was referencing `.Params.framed`,
which looks for the `framed` parameter in the local document metadata,
rather than in the site configuration.

This commit replaces it with `$.Site.Params.framed`, allowing you to frame
the index content by setting in `config.toml`:

```
[params]
framed = true
```
