### PR TITLE
add `hiddenPage` mode

### DIFF
--- a/layouts/_default/_markup/render-link.html
+++ b/layouts/_default/_markup/render-link.html
@@ -1,0 +1,1 @@
+<a href="{{ .Destination | safeURL }}" {{ with .Title }}title="{{ . }}"{{ end }} {{ if strings.HasPrefix .Destination "http" | and (.Page.Params.hiddenPage | in (slice true "true")) }}target="_blank" rel="nofollow noopener noreferrer"{{ end }}>{{ .Text | safeHTML }}</a>

--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -12,7 +12,8 @@
     {{ if .IsHome }}
       {{ $PageContext = .Site }}
     {{ end }}
-    {{ $paginator := .Paginate (where $PageContext.RegularPages "Type" $contentTypeName) }}
+    {{ $pages := where $PageContext.RegularPages "Type" $contentTypeName }}
+    {{ $paginator := .Paginate ( ( $pages | symdiff (where $pages "Params.hiddenPage" "==" "true")) | symdiff (where $pages "Params.hiddenPage" "==" true) ) }}
 
     {{ range $paginator.Pages }}
       <article class="post on-list">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -5,7 +5,8 @@
     </div>
   {{ end }}
   <div class="posts">
-    {{ range .Paginator.Pages }}
+    {{ $paginator := .Paginate ( (.Pages | symdiff (where .Pages "Params.hiddenPage" "==" "true")) | symdiff (where .Pages "Params.hiddenPage" true) ) }}
+    {{ range $paginator.Pages }}
       <article class="post on-list">
         <h1 class="post-title">
           <a href="{{ .Permalink }}">{{ .Title | markdownify }}</a>

--- a/layouts/_default/robots.txt
+++ b/layouts/_default/robots.txt
@@ -1,0 +1,4 @@
+User-Agent: *
+{{ range ((where site.Pages "Params.hiddenPage" "==" "true") | union (where site.Pages "Params.hiddenPage" true)) -}}
+Disallow: {{ .RelPermalink }}
+{{ end }}

--- a/layouts/_default/rss.xml
+++ b/layouts/_default/rss.xml
@@ -10,6 +10,7 @@
 {{- if ge $limit 1 -}}
 {{- $pages = $pages | first $limit -}}
 {{- end -}}
+{{- $pages = ($pages | symdiff (where $pages "Params.hiddenPage" "==" "true")) | symdiff (where $pages "Params.hiddenPage" true) -}}
 {{- printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom">
   <channel>

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,0 +1,24 @@
+{{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
+  xmlns:xhtml="http://www.w3.org/1999/xhtml">
+  {{ range .Data.Pages }}
+    {{- if .Permalink -}}
+  <url>
+    <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}
+    <lastmod>{{ safeHTML ( .Lastmod.Format "2006-01-02T15:04:05-07:00" ) }}</lastmod>{{ end }}{{ with .Sitemap.ChangeFreq }}
+    <changefreq>{{ . }}</changefreq>{{ end }}{{ if ge .Sitemap.Priority 0.0 }}
+    <priority>{{ .Sitemap.Priority }}</priority>{{ end }}{{ if .IsTranslated }}{{ range .Translations }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+    <xhtml:link
+                rel="alternate"
+                hreflang="{{ .Language.Lang }}"
+                href="{{ .Permalink }}"
+                />{{ end }}
+  </url>
+    {{- end -}}
+  {{ end }}
+</urlset>

--- a/layouts/_default/sitemap.xml
+++ b/layouts/_default/sitemap.xml
@@ -1,7 +1,7 @@
 {{ printf "<?xml version=\"1.0\" encoding=\"utf-8\" standalone=\"yes\"?>" | safeHTML }}
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9"
   xmlns:xhtml="http://www.w3.org/1999/xhtml">
-  {{ range .Data.Pages }}
+  {{ range (.Pages | symdiff (where .Pages "Params.hiddenPage" "==" "true")) | symdiff (where .Pages "Params.hiddenPage" true) }}
     {{- if .Permalink -}}
   <url>
     <loc>{{ .Permalink }}</loc>{{ if not .Lastmod.IsZero }}

--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -3,13 +3,16 @@
     <h1>{{ .Title }}</h1>
     <ul>
       {{ $type := .Type }}
-      {{ range $key, $value := .Data.Terms.Alphabetical }}
-      {{ $name := .Name }}
-      {{ $count := .Count }}
+      {{ range $term := .Data.Terms.Alphabetical }}
+      {{ $termPages := (.Pages | symdiff (where .Pages "Params.hiddenPage" "==" "true")) | symdiff (where .Pages "Params.hiddenPage" true) }}
+      {{ if (len $termPages | ne 0) }}
+      {{ $name := $term.Name }}
+      {{ $count := len $termPages }}
       {{ with $.Site.GetPage (printf "/%s/%s" $type $name) }}
         <li>
           <a class="terms-title" href="{{ .Permalink }}">{{ .Name }} ({{ $count }})</a>
         </li>
+      {{ end }}
       {{ end }}
       {{ end }}
     </ul>

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,10 +2,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="{{ if .IsHome }}{{ $.Site.Params.Subtitle }}{{ else if .Description}}{{ .Description | plainify }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
 <meta name="keywords" content="{{ with .Params.Keywords }}{{ delimit . ", " }}{{ else }}{{ $.Site.Params.Keywords }}{{ end }}" />
-{{ if .Params.noindex }}
-  {{ if or (eq (.Param "noindex") true) (eq (.Param "noindex") "true") }}
-    <meta name="robots" content="noindex" /> 
-  {{ end }}
+{{ if .Params.hiddenPage | or .Params.noindex | in (slice "true" true) }}
+    <meta name="robots" content="noindex,nofollow" />
 {{ else }}
   <meta name="robots" content="noodp" />
 {{ end }}


### PR DESCRIPTION
Setting this page-level param to `true` hides the page from:
- Home Page
- Terms Page
- List Page
- Sitemap
- RSS feed
- robots.txt

It also adds `noindex,nofollow` in the `head` and a `Disallow` directive in the `robots.txt` file.

Of course, this doesn't guarantee absolute confidentiality since how and where the link is shared could also make it "discoverable" but is way better than only adding the `noindex` directive.