### PR TITLE
Show content if available in terms.html

### DIFF
--- a/layouts/_default/terms.html
+++ b/layouts/_default/terms.html
@@ -1,6 +1,11 @@
 {{ define "main" }}
   <div class="terms">
     <h1>{{ .Title }}</h1>
+    {{ with .Content }}
+        <div class="index-content">
+            {{ . }}
+        </div>
+    {{ end }}
     <ul>
       {{ $type := .Type }}
       {{ range $key, $value := .Data.Terms.Alphabetical }}


### PR DESCRIPTION
Currently navigating to `/<TERMS>/` does not show the content, even if it is defined in `/content/<TERMS>/_index.md`.
This PR aims to fixe that.