### PR TITLE
Added heading to term pages

### DIFF
--- a/assets/css/style.scss
+++ b/assets/css/style.scss
@@ -16,4 +16,5 @@
 @import "syntax";
 @import "code";
 @import "terms";
+@import "term";
 @import "gist";

--- a/assets/css/term.scss
+++ b/assets/css/term.scss
@@ -1,0 +1,3 @@
+h1.term {
+  color: $accent;
+}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,0 +1,57 @@
+{{ define "main" }}
+  <h1 class="term">{{ .Title }}</h1>
+  {{ with .Content }}
+    <div class="index-content">
+      {{ . }}
+    </div>
+  {{ end }}
+  <div class="posts">
+    {{ range .Paginator.Pages }}
+      <article class="post on-list">
+        <h1 class="post-title">
+          <a href="{{ .Permalink }}">{{ .Title | markdownify }}</a>
+        </h1>
+        <div class="post-meta">
+          {{ if .Date }}
+            <time class="post-date">
+              {{ .Date.Format "2006-01-02" }} ::
+            </time>
+          {{ end }}
+          {{ with .Params.Author }}
+            <span class="post-author">{{ . }}</span>
+          {{ end }}
+        </div>
+
+        {{ if .Params.tags }}
+          <span class="post-tags">
+            {{ range .Params.tags }}
+            #<a href="{{ (urlize (printf "tags/%s/" . )) | absLangURL }}">
+              {{- . -}}
+            </a>&nbsp;
+            {{ end }}
+          </span>
+        {{ end }}
+
+        {{ partial "cover.html" . }}
+
+        <div class="post-content">
+          {{ if .Params.showFullContent }}
+            {{ .Content }}
+          {{ else if .Description }}
+            {{ .Description | markdownify }}
+          {{ else }}
+            {{ .Summary }}
+          {{ end }}
+        </div>
+
+        {{ if not .Params.showFullContent }}
+          <div>
+            <a class="read-more button" href="{{.RelPermalink}}">{{ $.Site.Params.ReadMore }} →</a>
+          </div>
+        {{ end }}
+      </article>
+    {{ end }}
+
+    {{ partial "pagination.html" . }}
+  </div>
+{{ end }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -14,11 +14,11 @@
         <div class="post-meta">
           {{ if .Date }}
             <time class="post-date">
-              {{ .Date.Format "2006-01-02" }} ::
+              {{ .Date.Format "2006-01-02" }}
             </time>
           {{ end }}
           {{ with .Params.Author }}
-            <span class="post-author">{{ . }}</span>
+            <span class="post-author"> :: {{ . }}</span>
           {{ end }}
         </div>
 


### PR DESCRIPTION
By basically copying `list.html` but editing it to include a `<h1>` for the title.
Not sure if this is the best way to style it, but I tested it locally to confirm it works.
This should close #429