### PR TITLE
Fixed stray `::` when there's no other content to show

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -13,11 +13,11 @@
         <div class="post-meta">
           {{ if .Date }}
             <time class="post-date">
-              {{ .Date.Format "2006-01-02" }} ::
+              {{ .Date.Format "2006-01-02" }}
             </time>
           {{ end }}
           {{ with .Params.Author }}
-            <span class="post-author">{{ . }}</span>
+          :: <span class="post-author">{{ . }}</span>
           {{ end }}
         </div>
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -6,14 +6,14 @@
   <div class="post-meta">
     {{ if .Date }}
       <time class="post-date">
-        {{ .Date.Format "2006-01-02" }} ::
+        {{ .Date.Format "2006-01-02" }}
         {{ if $.Site.Params.showLastUpdated }}
-          [{{or $.Site.Params.updatedDatePrefix "Updated"}} :: {{ .Lastmod.Format "2006-01-02" }}]
+          :: [{{or $.Site.Params.updatedDatePrefix "Updated"}} :: {{ .Lastmod.Format "2006-01-02" }}]
         {{ end }}
       </time>
     {{ end }}
     {{ with .Params.Author }}
-      <span class="post-author">{{ . }}</span>
+      <span class="post-author"> :: {{ . }}</span>
     {{ end }}
     {{ if and (.Param "readingTime") (eq (.Param "readingTime") true) }}
       <span class="post-reading-time">:: {{ .ReadingTime }} {{ $.Site.Params.minuteReadingTime | default "min read" }} ({{ .WordCount }} {{ $.Site.Params.words | default "words" }})</span>


### PR DESCRIPTION
This PR moves the `::` character so that it's only visible under the condition that the accompanying content will be shown
I assume the duplicated `:;` is bug, it should only be shown once between each component to act as a delimiter

Some images of the patch:

Changes to list.html:
list without author ![list without author](https://user-images.githubusercontent.com/9031498/235356891-51a2dca8-7408-4c58-849d-dae0f42f9b08.png)

Changes to single.html
without update or author ![without update or author](https://user-images.githubusercontent.com/9031498/235356995-6cbcb2bb-3836-472a-9f42-525981766e68.png)

# Original appearances:
Before the fixes, In both images, notice the redundant `::`
in single.html:
![image](https://user-images.githubusercontent.com/9031498/235357052-417862f0-6f6f-4915-b7dd-b853d490a721.png)
In list.html:
![image](https://user-images.githubusercontent.com/9031498/235357112-6a2a819b-1d2a-4a60-a704-fa0959cc40cf.png)
