### PR TITLE
Update main.scss to fix footnote counting issue

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -262,31 +262,31 @@ ol {
 ol {
   list-style: none;
   counter-reset: li;
-}
 
-ol > li {
-  counter-increment: li;
-}
+  > li {
+    counter-increment: li;
 
-ol > li:before {
-  content: counter(li);
-  position: absolute;
-  right: calc(100% + 10px);
-  color: $accent;
-  display: inline-block;
-  text-align: right;
-}
+    &:before {
+      content: counter(li);
+      position: absolute;
+      right: calc(100% + 10px);
+      color: $accent;
+      display: inline-block;
+      text-align: right;
+    }
 
-ol > ol {
-  margin-left: 38px;
-}
+    > ol {
+      margin-left: 38px;
 
-ol > ol > li {
-  counter-increment: li;
-}
+      > li {
+        counter-increment: li;
 
-ol > ol > li:before {
-  content: counters(li, ".") " ";
+        &:before {
+          content: counters(li, ".") " ";
+        }
+      }
+    }
+  }
 }
 
 mark {

--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -262,31 +262,31 @@ ol {
 ol {
   list-style: none;
   counter-reset: li;
+}
 
-  li {
-    counter-increment: li;
-  }
+ol > li {
+  counter-increment: li;
+}
 
-  li:before {
-    content: counter(li);
-    position: absolute;
-    right: calc(100% + 10px);
-    color: $accent;
-    display: inline-block;
-    text-align: right;
-  }
+ol > li:before {
+  content: counter(li);
+  position: absolute;
+  right: calc(100% + 10px);
+  color: $accent;
+  display: inline-block;
+  text-align: right;
+}
 
-  ol {
-    margin-left: 38px;
+ol > ol {
+  margin-left: 38px;
+}
 
-    li {
-      counter-increment: li;
-    }
+ol > ol > li {
+  counter-increment: li;
+}
 
-    li:before {
-      content: counters(li, ".") " ";
-    }
-  }
+ol > ol > li:before {
+  content: counters(li, ".") " ";
 }
 
 mark {


### PR DESCRIPTION
As I discovered in this [issue](https://github.com/panr/hugo-theme-terminal/issues/462), the theme does not count footnotes properly if there is a list contained within the footnote. I modified the CSS to only count the top level list (the footnotes) and not any lists contained within the footnote.

This is working well on my personal site, but please check the CSS to make sure everything looks right. I am no expert!