### PR TITLE
add KaTeX support as a community feature

### DIFF
--- a/COMMUNITY-FEATURES.md
+++ b/COMMUNITY-FEATURES.md
@@ -23,3 +23,7 @@ eg:
 - **Single Page Website** (https://github.com/justinnuwin/hugo-theme-terminal)
   - A layout where the homepage can render lists of pages and the navigation menu can link to sections on the homepage.
   - Justin Nguyen, software and hardware developer.
+
+- **Support for beautiful *KaTeX* formulae** ([amtoine/hugo-theme-terminal-katex](https://github.com/amtoine/hugo-theme-terminal-katex))
+  - SHORT DESCRIPTION
+  - Antoine Stevan ([@amtoine](https://github.com/amtoine)), software engineer into open source


### PR DESCRIPTION
hello there :wave: :yum: 

i wanted to have some beautiful formulae in my personal website and saw #224.
it appears it has never been added as a community feature in [`COMMUNITY-FEATURES.md`](https://github.com/panr/hugo-theme-terminal/blob/master/COMMUNITY-FEATURES.md) so here it is :blush: 

this is greatly inspired by [this blog post](https://petercheng.me/blog/rendering-latex-with-katex-in-a-hugo-blog/) :+1: 

- i've added some instructions at the [top of the README](https://github.com/amtoine/hugo-theme-terminal-katex#terminal)
- the changes added by the feature can be seen [here](https://github.com/amtoine/hugo-theme-terminal-katex/compare/9726b8d..master)