### PR TITLE
Fix non-https link to gohugo.io

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -5,7 +5,7 @@
         <span>{{ $.Site.Copyright | safeHTML }}</span>
     {{ else }}
       <div class="copyright">
-        <span>© {{ now.Year }} Powered by <a href="http://gohugo.io">Hugo</a></span>
+        <span>© {{ now.Year }} Powered by <a href="https://gohugo.io">Hugo</a></span>
     {{ end }}
       <span>:: <a href="https://github.com/panr/hugo-theme-terminal" target="_blank">Theme</a> made by <a href="https://github.com/panr" target="_blank">panr</a></span>
       </div>


### PR DESCRIPTION
Fixes the non-secure link to gohugo.io, which sometimes causes security suites to present a warning about non-secure external links