### PR TITLE
delete unused css vars

### DIFF
--- a/assets/css/variables.scss
+++ b/assets/css/variables.scss
@@ -6,9 +6,3 @@ $border-color: rgba(255, 255, 255, .1);
 /* MEDIA QUERIES */
 $phone: "max-width: 684px";
 $tablet: "max-width: 900px";
-
-/* variables for js, must be the same as these in @custom-media queries */
-:root {
-  --phoneWidth: (max-width: 684px);
-  --tabletWidth: (max-width: 900px);
-}


### PR DESCRIPTION
I couldn't find any reference to these vars or where these are being used. Could just be an oversight when porting the theme to use Hugo Pipes.