### PR TITLE
add options to hide cover image

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -41,7 +41,9 @@
           </span>
         {{ end }}
 
+        {{ if not (.Param "hideCoverInLists") }}
         {{ partial "cover.html" . }}
+        {{ end }}
 
         <div class="post-content">
           {{ if .Params.showFullContent }}

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -31,7 +31,9 @@
           </span>
         {{ end }}
 
+        {{ if not (.Param "hideCoverInLists") }}
         {{ partial "cover.html" . }}
+        {{ end }}
 
         <div class="post-content">
           {{ if .Params.showFullContent }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -27,7 +27,10 @@
       {{ end }}
     </span>
   {{ end }}
+
+  {{ if not (.Param "hideCover") }}
   {{ partial "cover.html" . }}
+  {{ end }}
 
   {{ if (.Params.Toc | default .Site.Params.Toc) }}
     <div class="table-of-contents">


### PR DESCRIPTION
this could help in the case when one wants to use the set cover image for social media previews but not show it on the site.

PS: this does not account for the case wherein `true`/`false` are set as strings in the frontmatter