### PR TITLE
Add built in mermaid support to theme?

### DIFF
--- a/layouts/_default/_markup/render-codeblock-mermaid.html
+++ b/layouts/_default/_markup/render-codeblock-mermaid.html
@@ -1,0 +1,4 @@
+<pre class="mermaid">
+  {{- .Inner | safeHTML }}
+</pre>
+{{ .Page.Store.Set "hasMermaid" true }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -54,4 +54,10 @@
     {{ partial "comments.html" . }}
   {{ end }}
 </article>
+{{ if .Store.Get "hasMermaid" }}
+  <script type="module">
+    import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid/dist/mermaid.esm.min.mjs';
+    mermaid.initialize({ startOnLoad: true });
+  </script>
+{{ end }}
 {{ end }}


### PR DESCRIPTION
Hey @panr, really love this theme! 

I added [mermaid](http://mermaid.js.org/) support as described in the [Hugo docs](https://gohugo.io/content-management/diagrams/#mermaid-diagrams). My peers and I find `mermaid` really useful for communicating ideas, so if it doesn't add too much complexity to the theme it does make `mermaid` diagrams "just work."