### PR TITLE
Update post.css

### DIFF
--- a/assets/css/post.css
+++ b/assets/css/post.css
@@ -81,7 +81,7 @@
 }
 
 .post-cover {
-  margin: 40px 0;
+  margin: auto;
 }
 
 .post ul {


### PR DESCRIPTION
change the post-cover value from `40px 0` to `auto` in file 

> /assets/css/post.css

 to ensure that any posts cover image will be automatically centered for a better and neater visual impression.