### PR TITLE
fix permalink to respect baseURL

### DIFF
--- a/layouts/_default/index.html
+++ b/layouts/_default/index.html
@@ -55,7 +55,7 @@
 
         {{ if not .Params.showFullContent }}
           <div>
-            <a class="read-more button inline" href="{{ .RelPermalink }}">{{ $.Site.Params.ReadMore }}</a>
+            <a class="read-more button inline" href="{{ .PermaLink }}">{{ $.Site.Params.ReadMore }}</a>
           </div>
         {{ end }}
       </article>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -45,7 +45,7 @@
 
         {{ if not .Params.showFullContent }}
            <div>
-            <a class="read-more button inline" href="{{ .RelPermalink }}">{{ $.Site.Params.ReadMore }}</a>
+            <a class="read-more button inline" href="{{ .PermaLink }}">{{ $.Site.Params.ReadMore }}</a>
           </div>
         {{ end }}
       </article>

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -46,7 +46,7 @@
 
         {{ if not .Params.showFullContent }}
           <div>
-            <a class="read-more button inline" href="{{ .RelPermalink }}">{{ $.Site.Params.ReadMore }}</a>
+            <a class="read-more button inline" href="{{ .PermaLink }}">{{ $.Site.Params.ReadMore }}</a>
           </div>
         {{ end }}
       </article>

--- a/layouts/partials/cover.html
+++ b/layouts/partials/cover.html
@@ -3,14 +3,14 @@
 
 {{- if index .Params "cover" -}}
   {{- if .Resources.GetMatch .Params.Cover }}
-    {{- $cover = (.Resources.GetMatch .Params.Cover).RelPermalink -}}
+    {{- $cover = (.Resources.GetMatch .Params.Cover).PermaLink -}}
   {{- else -}}
     {{- $cover = absURL .Params.Cover -}}
   {{- end -}}
 {{- else if $.Site.Params.AutoCover -}}
   {{- if (not .Params.Cover) -}}
     {{- if .Resources.GetMatch "cover.*" -}}
-      {{- $cover = (.Resources.GetMatch "cover.*").RelPermalink -}}
+      {{- $cover = (.Resources.GetMatch "cover.*").PermaLink -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -17,7 +17,7 @@
 
 {{ $bundle := slice $menu $prism | resources.Concat "bundle.js" | resources.Minify }}
 
-<script type="text/javascript" src="{{ $bundle.RelPermalink }}"></script>
+<script type="text/javascript" src="{{ $bundle.PermaLink }}"></script>
 
 <!-- Extended footer section-->
 {{ partial "extended_footer.html" . }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -50,7 +50,7 @@
 {{ if (isset .Params "cover") }}
   {{ $pageCover := .Param "cover" }}
   {{ with (.Resources.GetMatch (.Param "cover")) }}
-    {{ $pageCover = .RelPermalink }}
+    {{ $pageCover = .PermaLink }}
   {{ end }}
   <meta property="og:image" content="{{ $pageCover | absURL }}">
 {{ else }}
@@ -67,12 +67,12 @@
 
 <!-- RSS -->
 {{ with .OutputFormats.Get "RSS" }}
-  <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+  <link href="{{ .PermaLink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
 {{ end }}
 
 <!-- JSON Feed -->
 {{ with .OutputFormats.Get "json" }}
-  <link href="{{ .RelPermalink }}" rel="alternate" type="application/json" title="{{ $.Site.Title }}" />
+  <link href="{{ .PermaLink }}" rel="alternate" type="application/json" title="{{ $.Site.Title }}" />
 {{ end }}
 
 <!-- Extended head section-->


### PR DESCRIPTION
Noticed that the theme would break when I deployed to GH Pages because it ignores the baseURL (which is impossible to avoid with GH Pages specifically, and does require a nice bit of configuration if done after building with some nginx rule replacement etc).
 
This was being caused due to the fact that there was a use of 'RelPermaLink' instead of 'PermaLink' - adding in those changes in this PR