### PR TITLE
Fix figure tag display issue

### DIFF
--- a/assets/css/terminal.css
+++ b/assets/css/terminal.css
@@ -211,6 +211,10 @@ img {
   overflow: hidden;
 }
 
+figure {
+  width: fit-content;
+}
+
 figure img,
 figure video {
   margin-bottom: 0;


### PR DESCRIPTION
## Problem：Figure with a caption

```markdown
{{< figure src="1.jpg" alt="Terminal Theme Preview" position="center" caption="Terminal Theme Preview" captionPosition="center" >}}
```

When the image `width` is not greater than `.content` width, the display issue occurs.

![捕获](https://github.com/user-attachments/assets/898e8ff7-d676-4a42-abca-41c237d28cc6)

Adding a `width` attribute to the `<figure>` tag can fix the issue.