### PR TITLE
Replaced deprecated "paginate" key with "pagination.pagerSize"

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,7 +161,7 @@ languageCode = "en-us"
 # Add it only if you keep the theme in the `themes` directory.
 # Remove it if you use the theme as a remote Hugo Module.
 theme = "terminal"
-paginate = 5
+pagination.pagerSize = 5
 
 [params]
   # dir name of your main content (default is `content/posts`).

--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,7 +1,7 @@
 baseurl = "https://example.com/"
 languageCode = "en-us"
 theme = "hugo-theme-terminal"
-paginate = 5
+pagination.pagerSize = 5
 
 [markup.goldmark.renderer]
   unsafe = true


### PR DESCRIPTION
Due to 
`ERROR deprecated: site config key paginate was deprecated in Hugo v0.128.0 and will be removed in Hugo 0.141.0. Use pagination.pagerSize instead.`

Changed both occurrences in the project.