### PR TITLE
added mastodon verification

### DIFF
--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -2,6 +2,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <meta name="description" content="{{ if .IsHome }}{{ $.Site.Params.Subtitle }}{{ else if .Description}}{{ .Description | plainify }}{{ else }}{{ .Summary | plainify }}{{ end }}" />
 <meta name="keywords" content="{{ with .Params.Keywords }}{{ delimit . ", " }}{{ else }}{{ $.Site.Params.Keywords }}{{ end }}" />
+
+
 {{ if .Params.noindex }}
   {{ if or (eq (.Param "noindex") true) (eq (.Param "noindex") "true") }}
     <meta name="robots" content="noindex" />
@@ -38,6 +40,14 @@
     <meta name="twitter:site" content="{{ $.Site.Params.Twitter.site }}" />
   {{ end }}
     <meta name="twitter:creator" content="{{ if .IsHome }}{{ $.Site.Params.Twitter.creator }}{{ else if isset .Params "authortwitter" }}{{ .Params.authorTwitter }}{{ else }}{{ .Params.Author }}{{ end }}" />
+{{ end }}
+
+<!-- Mastodon verification -->
+<meta name="mastodon:verification" content="summary" />
+{{ if (isset $.Site.Params "mastodon") }}
+  {{ if (isset $.Site.Params.mastodon "url") }}
+    <link href="{{ $.Site.Params.mastodon.url }}" rel="me">
+  {{ end }}
 {{ end }}
 
 <!-- OG data -->


### PR DESCRIPTION
I wanted an easy way to add verification for Mastodon for my blog.

I made some minor changes to the head.html file to add similar logic to the twitter card block.

In my Hugo config, I added a new config value.

```
[params.mastodon]
  url = "<URL_GOES_HERE>"
```