### PR TITLE
fixed theme in default template to match configuration documentation

### DIFF
--- a/exampleSite/config.toml
+++ b/exampleSite/config.toml
@@ -1,6 +1,6 @@
 baseurl = "https://example.com/"
 languageCode = "en-us"
-theme = "hugo-theme-terminal"
+theme = "terminal"
 pagination.pagerSize = 5
 
 [markup.goldmark.renderer]


### PR DESCRIPTION
The name for the theme that was in the "exampleSite" configuration was incorrect, and would lead to this error on my end:

Error: command error: failed to load modules: module "hugo-theme-terminal" not found in "/Users/jackson/Documents/quickstart/themes/hugo-theme-terminal"; either add it as a Hugo Module or store it in "/Users/jackson/Documents/quickstart/themes".: module does not exist

Editing it to just "terminal" fixed it.