### PR TITLE
Update footer template make the copyright param work

### DIFF
--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,8 +1,8 @@
 <footer class="footer">
   <div class="footer__inner">
-    {{ if $.Site.Copyright }}
+    {{ if $.Site.Params.Copyright }}
       <div class="copyright copyright--user">
-        <span>{{ $.Site.Copyright | safeHTML }}</span>
+        <span>{{ $.Site.Params.Copyright | safeHTML }}</span>
     {{ else }}
       <div class="copyright">
         <span>© {{ now.Year }} Powered by <a href="https://gohugo.io">Hugo</a></span>


### PR DESCRIPTION
The copyright param wasn't working. So, I fixed the footer template to make it work.