### PR TITLE
Replace hardcoded Menu string with menuMore from site configuration

### DIFF
--- a/layouts/partials/mobile-menu.html
+++ b/layouts/partials/mobile-menu.html
@@ -1,5 +1,5 @@
 <ul class="menu menu--mobile">
-  <li class="menu__trigger">Menu&nbsp;▾</li>
+  <li class="menu__trigger">{{ $.Site.Params.menuMore }}&nbsp;▾</li>
   <li>
     <ul class="menu__dropdown">
       {{ range $.Site.Menus.main }}


### PR DESCRIPTION
`mobile-menu.html` partials uses hardcoded value for _"Menu"_ label. I've change it on my site, but I think this change would be useful for others as well.