### PR TITLE
Improving the translation menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,11 @@ pagination.pagerSize = 5
   # show selector to switch language
   showLanguageSelector = false
 
+  # the language selector always links...
+  # - true: the translated content equivalent (e.g. /en/posts/some-post directly → /de/posts/some-post), 
+  # - false: just to the translated root (e.g. /en/posts/some-post → /de)
+  changeLanguageOfCurrentPage = true  # (default: false)
+
   # set theme to full screen width
   fullWidthTheme = false
 

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ pagination.pagerSize = 5
   # the language selector always links...
   # - true: the translated content equivalent (e.g. /en/posts/some-post directly → /de/posts/some-post), 
   # - false: just to the translated root (e.g. /en/posts/some-post → /de)
-  changeLanguageOfCurrentPage = true  # (default: false)
+  #changeLanguageOfCurrentPage = true  # (default: false)
 
   # set theme to full screen width
   fullWidthTheme = false

--- a/layouts/partials/language-menu.html
+++ b/layouts/partials/language-menu.html
@@ -1,9 +1,14 @@
 <ul class="menu menu--desktop menu--language-selector">
-  <li class="menu__trigger">{{ .Language.LanguageName }}&nbsp;▾</li>
+  <li class="menu__trigger">{{ .Language.LanguageCode }}&nbsp;▾</li>
   <li>
     <ul class="menu__dropdown">
       {{ range $.Site.Home.AllTranslations }}
-        <li><a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a></li>
+        {{ $current_page_url_without_language_prefix := strings.TrimPrefix (print "/" $.Language.LanguageCode "/") $.Page.RelPermalink }}
+        {{ if .GetPage $current_page_url_without_language_prefix }}
+          <li><a href="{{ .RelPermalink }}{{ $current_page_url_without_language_prefix }}">{{ .Language.LanguageName }}</a></li>
+        {{ else }}
+          <li><a href="{{ .RelPermalink }}">({{ .Language.LanguageName }})</a></li>
+        {{ end }}
       {{ end }}
     </ul>
   </li>

--- a/layouts/partials/language-menu.html
+++ b/layouts/partials/language-menu.html
@@ -2,14 +2,29 @@
   <li class="menu__trigger">{{ .Language.LanguageCode }}&nbsp;▾</li>
   <li>
     <ul class="menu__dropdown">
+      {{ $current_page_url_without_language_prefix := strings.TrimPrefix (print "/" $.Language.LanguageCode "/") $.Page.RelPermalink }}
       {{ range $.Site.Home.AllTranslations }}
-        {{ $current_page_url_without_language_prefix := strings.TrimPrefix (print "/" $.Language.LanguageCode "/") $.Page.RelPermalink }}
-        {{ if .GetPage $current_page_url_without_language_prefix }}
-          <li><a href="{{ .RelPermalink }}{{ $current_page_url_without_language_prefix }}">{{ .Language.LanguageName }}</a></li>
+        {{ if not ($.Site.Params.changeLanguageOfCurrentPage | default false) }}
+          <li>
+            {{ if eq $.Language.LanguageCode .Language.LanguageCode }}<b>{{ end }}
+            <a href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+            {{ if eq $.Language.LanguageCode .Language.LanguageCode }}</b>{{ end }}
+          </li>
+        {{ else if .GetPage $current_page_url_without_language_prefix }}
+          <li>
+            {{ if eq $.Language.LanguageCode .Language.LanguageCode }}<b>{{ end }}
+            <a href="{{ .RelPermalink }}{{ $current_page_url_without_language_prefix }}">{{ .Language.LanguageName }}</a>
+            {{ if eq $.Language.LanguageCode .Language.LanguageCode }}</b>{{ end }}
+          </li>
         {{ else }}
-          <li><a href="{{ .RelPermalink }}">({{ .Language.LanguageName }})</a></li>
+          <li>
+            {{ if eq $.Language.LanguageCode .Language.LanguageCode }}<b>{{ end }}
+            <a href="{{ .RelPermalink }}">({{ .Language.LanguageName }})</a>
+            {{ if eq $.Language.LanguageCode .Language.LanguageCode }}</b>{{ end }}
+          </li>
         {{ end }}
       {{ end }}
     </ul>
   </li>
 </ul>
+

--- a/layouts/partials/mobile-menu.html
+++ b/layouts/partials/mobile-menu.html
@@ -9,10 +9,27 @@
       {{ end }}
       {{ if and $.Site.Params.showLanguageSelector (len $.Site.Home.AllTranslations) }}
         <hr />
+        {{ $current_page_url_without_language_prefix := strings.TrimPrefix (print "/" $.Language.LanguageCode "/") $.Page.RelPermalink }}
         {{ range $.Site.Home.AllTranslations }}
-          <li>
-            <a href="{{ .RelPermalink }}{{ strings.TrimPrefix (print "/" $.Language.LanguageCode "/") $.Page.RelPermalink }}">{{ .Language.LanguageName }}</a>
-          </li>
+          {{ if not ($.Site.Params.changeLanguageOfCurrentPage | default false) }}
+            <li>
+              {{ if eq $.Language.LanguageCode .Language.LanguageCode }}<b>{{ end }}
+              <a href="{{ .RelPermalink }}">{{ .Language.LanguageName }}</a>
+              {{ if eq $.Language.LanguageCode .Language.LanguageCode }}</b>{{ end }}
+            </li>
+          {{ else if .GetPage $current_page_url_without_language_prefix }}
+            <li>
+              {{ if eq $.Language.LanguageCode .Language.LanguageCode }}<b>{{ end }}
+              <a href="{{ .RelPermalink }}{{ $current_page_url_without_language_prefix }}">{{ .Language.LanguageName }}</a>
+              {{ if eq $.Language.LanguageCode .Language.LanguageCode }}</b>{{ end }}
+            </li>
+          {{ else }}
+            <li>
+              {{ if eq $.Language.LanguageCode .Language.LanguageCode }}<b>{{ end }}
+              <a href="{{ .RelPermalink }}">({{ .Language.LanguageName }})</a>
+              {{ if eq $.Language.LanguageCode .Language.LanguageCode }}</b>{{ end }}
+            </li>
+          {{ end }}
         {{ end }}
       {{ end }}
     </ul>

--- a/layouts/partials/mobile-menu.html
+++ b/layouts/partials/mobile-menu.html
@@ -11,7 +11,7 @@
         <hr />
         {{ range $.Site.Home.AllTranslations }}
           <li>
-            <a href="{{ .Permalink }}">{{ .Language.LanguageName }}</a>
+            <a href="{{ .RelPermalink }}{{ strings.TrimPrefix (print "/" $.Language.LanguageCode "/") $.Page.RelPermalink }}">{{ .Language.LanguageName }}</a>
           </li>
         {{ end }}
       {{ end }}


### PR DESCRIPTION
# Improved translation menu:

- make the current language appear bold
- all changes below are opt-in (using the config)
  - now, if a translation of the current page exists, it will directly link to it
  - if not, there are ( ) brackets put around this language
  - see the example config in README.md for the full info (but i guess that's it)

Please let me know if I missed to do something!