### PR TITLE
Improve how the reading time is displayed

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,6 +232,7 @@ pagination.pagerSize = 5
     title = "Terminal"
 
     [languages.en.params]
+      readingSpeed = 108  # in words per minute
       subtitle = "A simple, retro theme for Hugo"
       owner = ""
       keywords = ""

--- a/README.md
+++ b/README.md
@@ -243,8 +243,11 @@ pagination.pagerSize = 5
       olderPosts = "Older posts"
       missingContentMessage = "Page not found..."
       missingBackButtonLabel = "Back to home page"
-      minuteReadingTime = "min read"
       words = "words"
+      word = "word"
+      minute = "minute"
+      minutes = "minutes"
+      to_read = "to read"
 
       [languages.en.params.logo]
         logoText = "Terminal"

--- a/README.md
+++ b/README.md
@@ -232,7 +232,7 @@ pagination.pagerSize = 5
     title = "Terminal"
 
     [languages.en.params]
-      readingSpeed = 108  # in words per minute
+      # readingSpeed = 212  # in words per minute, default is 212
       subtitle = "A simple, retro theme for Hugo"
       owner = ""
       keywords = ""

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -15,8 +15,9 @@
     {{- with .Params.Author -}}
       <span class="post-author">{{ . }}</span>
     {{- end -}}
-    {{- if and (.Param "readingTime") (eq (.Param "readingTime") true) -}}
-      <span class="post-reading-time">{{ .ReadingTime }} {{ $.Site.Params.minuteReadingTime | default "min read" }} ({{ .WordCount }} {{ $.Site.Params.words | default "words" }})</span>
+    {{- if and (.Param "readingTime") (eq (.Param "readingTime") true) -}}{{ $customReadingTime := div (float .WordCount) .Site.Params.readingSpeed }}{{ $customReadingTime = math.Ceil $customReadingTime }}<!--
+      (browsers insert spaces (here) sometimes)
+      --><span class="post-reading-time">{{ $customReadingTime }} {{ if eq $customReadingTime 1.0 }}{{ $.Site.Params.minute | default "minute" }}{{ else }}{{ $.Site.Params.minutes | default "minutes" }}{{ end }} {{ $.Site.Params.to_read | default "to read" }} ({{ .WordCount }} {{ if eq .WordCount 1 }}{{ $.Site.Params.word | default "word" }}{{ else }}{{ $.Site.Params.words | default "words" }}{{ end }})</span>
     {{- end -}}
   </div>
 

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -15,7 +15,7 @@
     {{- with .Params.Author -}}
       <span class="post-author">{{ . }}</span>
     {{- end -}}
-    {{- if and (.Param "readingTime") (eq (.Param "readingTime") true) -}}{{ $customReadingTime := div (float .WordCount) .Site.Params.readingSpeed }}{{ $customReadingTime = math.Ceil $customReadingTime }}<!--
+    {{- if and (.Param "readingTime") (eq (.Param "readingTime") true) -}}{{ $customReadingTime := div (float .WordCount) (.Site.Params.readingSpeed | default 212) }}{{ $customReadingTime = math.Ceil $customReadingTime }}<!--
       (browsers insert spaces (here) sometimes)
       --><span class="post-reading-time">{{ $customReadingTime }} {{ if eq $customReadingTime 1.0 }}{{ $.Site.Params.minute | default "minute" }}{{ else }}{{ $.Site.Params.minutes | default "minutes" }}{{ end }} {{ $.Site.Params.to_read | default "to read" }} ({{ .WordCount }} {{ if eq .WordCount 1 }}{{ $.Site.Params.word | default "word" }}{{ else }}{{ $.Site.Params.words | default "words" }}{{ end }})</span>
     {{- end -}}


### PR DESCRIPTION
# Improve how the reading time is displayed

This PR

- fixes a singular/plural issue
- enables for translation of the reading-time specific strings
- gives the user the ability to customize the reading speed in words per minute (also language specific if wanted)

## (Probably) Breaking changes

- the "minuteReadingTime" variable in Site.Params has been removed (to allow for fixing the above listed issues)

---

If there is something I missed please tell me!