### PR TITLE
Terms listing improvements fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ pagination.pagerSize = 5
       missingBackButtonLabel = "Back to home page"
       minuteReadingTime = "min read"
       words = "words"
+      posts_for = "Posts for"  # used e.g. with tags (hugo 'taxonomies' in general)
 
       [languages.en.params.logo]
         logoText = "Terminal"

--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ pagination.pagerSize = 5
       missingBackButtonLabel = "Back to home page"
       minuteReadingTime = "min read"
       words = "words"
-      posts_for = "Posts for"  # used e.g. with tags (hugo 'taxonomies' in general)
+      posts_for = "Posts for"  # used e.g. with tags (hugo 'terms' in general)
 
       [languages.en.params.logo]
         logoText = "Terminal"

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <h1>Posts for: #{{ .Title }}</h1>
+  <h1>Posts for: #{{ .Name }}</h1>
   {{ with .Content }}
     <div class="index-content">
       {{ . }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <h1>{{ $.Site.Params.posts_for | default "Posts for" }}: #{{ .Name }}</h1>
+  <h1>{{ $.Site.Params.posts_for | default "Posts for" }}: <b style="opacity: 0.5;">#{{ .Name }}</b></h1>
   {{ with .Content }}
     <div class="index-content">
       {{ . }}

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,5 +1,5 @@
 {{ define "main" }}
-  <h1>Posts for: #{{ .Name }}</h1>
+  <h1>{{ $.Site.Params.posts_for | default "Posts for" }}: #{{ .Name }}</h1>
   {{ with .Content }}
     <div class="index-content">
       {{ . }}


### PR DESCRIPTION
Some changes made to the listing page of a given term, including

- added support for translating the "Posts for" string (non-breaking!)
- fixed wrong uppercase/lowercase format of the Term Name caused by using .Title instead of .Name on the term page
- beautified it a little bit (but if not wanted just don't take that commit): the term name now appears a little lighter/darker than the rest of the page title (opacity: 0.5)

Anything I missed? Something not as expected? Please let me know, I just want to make the theme even better!