### PR TITLE
Add option to translate the mobile menu title

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,7 @@ pagination.pagerSize = 5
       missingBackButtonLabel = "Back to home page"
       minuteReadingTime = "min read"
       words = "words"
+      menuTitle = "Menu"
 
       [languages.en.params.logo]
         logoText = "Terminal"

--- a/layouts/partials/mobile-menu.html
+++ b/layouts/partials/mobile-menu.html
@@ -1,5 +1,5 @@
 <ul class="menu menu--mobile">
-  <li class="menu__trigger">Menu&nbsp;▾</li>
+  <li class="menu__trigger">{{ $.Site.Params.menuTitle | default "Menu" }}&nbsp;▾</li>
   <li>
     <ul class="menu__dropdown">
       {{ range $.Site.Menus.main }}


### PR DESCRIPTION
This PR introduces the option to translate the mobile menu title (which was hard-coded to 'Menu' before) by setting the `$.Site.Params.menuTitle` variable. If this is not done - nothing changes, nothing breaks.

Something missing? Please tell me!