### PR TITLE
Added text size adjusters for mobile font sizing.

### DIFF
--- a/assets/css/code.css
+++ b/assets/css/code.css
@@ -20,6 +20,10 @@ pre code {
 
 code {
   color: var(--accent);
+  text-size-adjust: 100%;
+  -ms-text-size-adjust: 100%;
+  -moz-text-size-adjust: 100%;
+  -webkit-text-size-adjust: 100%;
 }
 
 .highlight {


### PR DESCRIPTION
Resolves #553. Font size on mobile increases depending on the length of the lines being outputted. 

@panr found a similar issue in https://github.com/adityatelange/hugo-PaperMod/issues/828

Adding these text sizers adjusters now keeps the font consistent with code blocks. 