### PR TITLE
fix(css/menu): use `max-content` as menu's width

### DIFF
--- a/assets/css/menu.css
+++ b/assets/css/menu.css
@@ -58,6 +58,7 @@
   left: 0;
   list-style: none;
   z-index: 99;
+  width: max-content;
 }
 
 .open .menu__dropdown {


### PR DESCRIPTION
Set the menu's width to `max-content` so it expands to fit its content
without wrapping.

Closes: #579

Duplicated: #580

Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/Reference/Values/max-content
