### PR TITLE
Improved table look (border color and size)

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -368,14 +368,22 @@ blockquote p:last-child {
 }
 
 table {
+  border: 8px solid var(--accent); /* fork added */
+  width: 100%; /* fork added */
   table-layout: auto;
   border-collapse: collapse;
 }
 
+/* fork added */
+th,
+td {
+  border: 6px solid var(--accent);
+}
+/* ========== */
+
 table,
 th,
 td {
-  border: 2px solid var(--foreground);
   padding: 10px;
 }
 
@@ -517,3 +525,4 @@ iframe[src*="youtube.com"] {
     display: initial;
   }
 }
+

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -368,18 +368,17 @@ blockquote p:last-child {
 }
 
 table {
-  border: 8px solid var(--accent); /* fork added */
-  width: 100%; /* fork added */
+  border: 8px solid var(--accent);
+  width: 100%;
   table-layout: auto;
   border-collapse: collapse;
+  text-align: left;
 }
 
-/* fork added */
 th,
 td {
-  border: 6px solid var(--accent);
+  border: 5px solid var(--accent);
 }
-/* ========== */
 
 table,
 th,


### PR DESCRIPTION
As I'm now using the theme in production for over a year, i created a table and was surprised the theme didn't really theme it correctly. This PR makes the following changes in main.css:

- set table width to 100% to create a concise look
- set outer table border size to 8px (as with images, etc.)
- set cell border size to 5px (as it looks pretty thick without this adaption; tested on mobile and desktop)
- set text-align in cells to left as justify just has to less space in the narrow cells and spacing looks ugly

Thanks for your great theme!