### PR TITLE
adds main landmark for accessibility

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -11,12 +11,16 @@
 
 <div class="{{- $container -}}{{- cond ($.Site.Params.oneHeadingSize | default false) " headings--one-size" "" }}">
 
+  <header>
   {{ partial "header.html" . }}
+  </header>
 
+  <main>
   <div class="content">
     {{ block "main" . }}
     {{ end }}
   </div>
+  </main>
 
   {{ block "footer" . }}
     {{ partial "footer.html" . }}


### PR DESCRIPTION
I noticed when working on <https://ordinary.blog> and checking <https://pagespeed.web.dev> that I was getting errors for "no main landmark" (which just means no `<main>` tag I'm pretty sure, as it was resolved after I [added one](https://codeberg.org/ordinarylabs/ordinary.blog/commit/f7afca86ed73f2e9ef40ec8557e42f96ef85c1a7)).

Doesn't seem to affect any of the styling, and worked for resolving that accessibility issue so figured I'd send it your way.

Thanks for making such a great theme!